### PR TITLE
Allow to set custom port

### DIFF
--- a/generator/src/develop.js
+++ b/generator/src/develop.js
@@ -16,7 +16,7 @@ const ClosurePlugin = require("closure-webpack-plugin");
 const readline = require("readline");
 
 module.exports = { start, run };
-function start({ routes, debug, manifestConfig }) {
+function start({ routes, debug, customPort, manifestConfig }) {
   const config = webpackOptions(false, routes, {
     debug,
     manifestConfig
@@ -51,9 +51,9 @@ function start({ routes, debug, manifestConfig }) {
     });
   });
 
-  const port = $.process.PORT || 3000;
+  const port = customPort || process.env.PORT || 3000;
   app.listen(port, () =>
-    console.log("🚀 elm-pages develop on http://localhost:port")
+    console.log(`🚀 elm-pages develop on http://localhost:${port}`)
   );
   // https://stackoverflow.com/questions/43667102/webpack-dev-middleware-and-static-files
   // app.use(express.static(__dirname + "/path-to-static-folder"));

--- a/generator/src/develop.js
+++ b/generator/src/develop.js
@@ -51,8 +51,9 @@ function start({ routes, debug, manifestConfig }) {
     });
   });
 
-  app.listen(3000, () =>
-    console.log("🚀 elm-pages develop on http://localhost:3000")
+  const port = $.process.PORT || 3000;
+  app.listen(port, () =>
+    console.log("🚀 elm-pages develop on http://localhost:port")
   );
   // https://stackoverflow.com/questions/43667102/webpack-dev-middleware-and-static-files
   // app.use(express.static(__dirname + "/path-to-static-folder"));

--- a/generator/src/elm-pages.js
+++ b/generator/src/elm-pages.js
@@ -102,6 +102,7 @@ function run() {
           develop.start({
             routes,
             debug: contents.debug,
+            customPort: contents.customPort,
             manifestConfig: payload.manifest
           });
         }


### PR DESCRIPTION
Closes #6 
This PR offers to possibility to change the port of the `develop` app: 

- `PORT=3200 elm-pages develop` which relies on the environment variable
- `elm-pages develop --port 3300` (cleaner) which uses an optional argument to set it.

in case both are present, the optional argument takes precedence.