### PR TITLE
Documentation typo: Metadata doesn't take a param

### DIFF
--- a/examples/docs/content/docs/directory-structure.md
+++ b/examples/docs/content/docs/directory-structure.md
@@ -25,7 +25,7 @@ your files (both code and content).
 Each file in the `content` folder will result in a new route for your static site. You can define how to render the types of document in the `content` folder based on the extension any way you like.
 
 ```elm
-helloDocument : Pages.Document.DocumentParser (Metadata) (List (Html Msg))
+helloDocument : Pages.Document.DocumentParser Metadata (List (Html Msg))
 helloDocument =
     Pages.Document.parser
         { extension = "txt"
@@ -51,7 +51,7 @@ helloDocument =
 ```
 
 ```elm
-markdownDocument : Pages.Document.DocumentParser (Metadata msg) (List (Element Msg))
+markdownDocument : Pages.Document.DocumentParser Metadata (List (Element Msg))
 markdownDocument =
     Pages.Document.parser
         { extension = "md"


### PR DESCRIPTION
Also: Removed redundant paranthesis.