### PR TITLE
Escape frontmatter content in raw records so it handles newlines

### DIFF
--- a/generator/src/generate-raw-content.js
+++ b/generator/src/generate-raw-content.js
@@ -19,8 +19,8 @@ function toEntry(entry, includeBody) {
 
   return `
   ( [${fullPath.join(", ")}]
-    , { frontMatter = """${entry.metadata}
-""" , body = ${body(entry, includeBody)}
+    , { frontMatter = ${JSON.stringify(entry.metadata)}
+    , body = ${body(entry, includeBody)}
     , extension = "${extension}"
     } )
   `;


### PR DESCRIPTION
Hey Dillon!

This change escapes frontmatter content with JSON.stringify so that it handles newlines correctly. Without using JSON.stringify, newlines are included directly in the output which caus parsing failures. The difference looks like this:

Before:
```
"""{\"example\": \"hello\nworld\"}
"""
```
After:
```
"{\"example\": \"hello\\nworld\"}"
```