### PR TITLE
Precache an empty shell as the service worker navigation route instead of the root route

### DIFF
--- a/generator/src/develop.js
+++ b/generator/src/develop.js
@@ -160,6 +160,10 @@ function webpackOptions(
         inject: "head",
         template: path.resolve(__dirname, "template.html")
       }),
+      new HTMLWebpackPlugin({
+        inject: "head",
+        filename: 'elm-pages-shell.html'
+      }),
       new ScriptExtHtmlWebpackPlugin({
         preload: /\.js$/,
         defaultAttribute: 'defer'
@@ -210,7 +214,7 @@ function webpackOptions(
       }),
       new InjectManifest({
         swSrc: path.resolve(__dirname, "./service-worker-template.js"),
-        include: [/^index\.html$/],
+        include: [/\.html/],
         exclude: [
           /android-chrome-.*\.png$/,
           /apple-touch-icon.*\.png/,

--- a/generator/src/service-worker-template.js
+++ b/generator/src/service-worker-template.js
@@ -2,7 +2,7 @@ workbox.core.skipWaiting();
 workbox.core.clientsClaim();
 workbox.precaching.precacheAndRoute(self.__precacheManifest);
 workbox.routing.registerNavigationRoute(
-  workbox.precaching.getCacheKeyForURL("/index.html"),
+  workbox.precaching.getCacheKeyForURL("/elm-pages-shell.html"),
   {
     blacklist: [/admin/]
   }


### PR DESCRIPTION
This fixes #52.