### PR TITLE
Properly setup the `renderAfterDocumentEvent` option

### DIFF
--- a/generator/src/add-files-plugin.js
+++ b/generator/src/add-files-plugin.js
@@ -54,7 +54,7 @@ module.exports = class AddFilesPlugin {
         };
       });
 
-      this.filesToGenerate.forEach(file => {
+      (this.filesToGenerate || []).forEach(file => {
         // Couldn't find this documented in the webpack docs,
         // but I found the example code for it here:
         // https://github.com/jantimon/html-webpack-plugin/blob/35a154186501fba3ecddb819b6f632556d37a58f/index.js#L470-L478

--- a/generator/src/develop.js
+++ b/generator/src/develop.js
@@ -229,10 +229,10 @@ function webpackOptions(
     },
     resolve: {
       modules: [
-        path.resolve(process.cwd(), `./node_modules`), 
+        path.resolve(process.cwd(), `./node_modules`),
         // TODO: find a cleaner way to do this.
         // This line just needs a way to point to the `node_modules` directory
-        // for the library bin (not the user's node_modules, which is the 
+        // for the library bin (not the user's node_modules, which is the
         // process.cwd prefixed node_modules above).
         path.resolve(path.dirname(require.resolve('webpack')), '../../'),
 
@@ -306,7 +306,9 @@ function webpackOptions(
         new PrerenderSPAPlugin({
           staticDir: path.join(process.cwd(), "dist"),
           routes: routes,
-          renderAfterDocumentEvent: "prerender-trigger"
+          renderer: new PrerenderSPAPlugin.PuppeteerRenderer({
+            renderAfterDocumentEvent: "prerender-trigger",
+          })
         })
       ],
       module: {
@@ -334,7 +336,7 @@ function webpackOptions(
         new webpack.NamedModulesPlugin(),
         // Prevents compilation errors causing the hot loader to lose state
         new webpack.NoEmitOnErrorsPlugin(),
-        new webpack.HotModuleReplacementPlugin() 
+        new webpack.HotModuleReplacementPlugin()
       ],
       module: {
         rules: [


### PR DESCRIPTION
@dillonkearns #61 didn't fix #40  for me, this does. It turns out the `renderAfterDocumentEvent` option wasn't properly set up.

`renderAfterDocumentEvent` should be passed as an option to an instance of `PrerenderSPAPlugin.PuppeteerRenderer`, not to the plugin itself.

See https://github.com/chrisvfritz/prerender-spa-plugin#advanced-usage-webpackconfigjs