### PR TITLE
Colorize elm compiler errors when running initial elm-pages.

### DIFF
--- a/generator/node-elm-compiler/index.js
+++ b/generator/node-elm-compiler/index.js
@@ -1,0 +1,207 @@
+'use strict';
+
+var spawn = require("cross-spawn");
+var _ = require("lodash");
+var elmBinaryName = "elm";
+var fs = require("fs");
+var path = require("path");
+var temp = require("temp").track();
+var findAllDependencies = require("find-elm-dependencies").findAllDependencies;
+
+var defaultOptions = {
+  spawn: spawn,
+  cwd: undefined,
+  pathToElm: undefined,
+  help: undefined,
+  output: undefined,
+  report: undefined,
+  debug: undefined,
+  verbose: false,
+  processOpts: undefined,
+  docs: undefined,
+  optimize: undefined,
+};
+
+var supportedOptions = _.keys(defaultOptions);
+
+function prepareSources(sources) {
+  if (!(sources instanceof Array || typeof sources === "string")) {
+    throw "compile() received neither an Array nor a String for its sources argument.";
+  }
+
+  return typeof sources === "string" ? [sources] : sources;
+}
+
+function prepareOptions(options, spawnFn) {
+  return _.defaults({ spawn: spawnFn }, options, defaultOptions);
+}
+
+function prepareProcessArgs(sources, options) {
+  var preparedSources = prepareSources(sources);
+  var compilerArgs = compilerArgsFromOptions(options);
+
+  return ["make"].concat(preparedSources ? preparedSources.concat(compilerArgs) : compilerArgs);
+}
+
+function prepareProcessOpts(options) {
+  var env = _.merge({ LANG: 'en_US.UTF-8' }, process.env);
+  return _.merge({ env: env, stdio: "inherit", cwd: options.cwd }, options.processOpts);
+
+}
+
+function runCompiler(sources, options, pathToElm) {
+  if (typeof options.spawn !== "function") {
+    throw "options.spawn was a(n) " + (typeof options.spawn) + " instead of a function.";
+  }
+
+  var processArgs = prepareProcessArgs(sources, options);
+  var processOpts = prepareProcessOpts(options);
+
+  if (options.verbose) {
+    console.log(["Running", pathToElm].concat(processArgs).join(" "));
+  }
+
+  return options.spawn(pathToElm, processArgs, processOpts);
+}
+
+function compilerErrorToString(err, pathToElm) {
+  if ((typeof err === "object") && (typeof err.code === "string")) {
+    switch (err.code) {
+      case "ENOENT":
+        return "Could not find Elm compiler \"" + pathToElm + "\". Is it installed?";
+
+      case "EACCES":
+        return "Elm compiler \"" + pathToElm + "\" did not have permission to run. Do you need to give it executable permissions?";
+
+      default:
+        return "Error attempting to run Elm compiler \"" + pathToElm + "\":\n" + err;
+    }
+  } else if ((typeof err === "object") && (typeof err.message === "string")) {
+    return JSON.stringify(err.message);
+  } else {
+    return "Exception thrown when attempting to run Elm compiler " + JSON.stringify(pathToElm);
+  }
+}
+
+function compileSync(sources, options) {
+  var optionsWithDefaults = prepareOptions(options, options.spawn || spawn.sync);
+  var pathToElm = options.pathToElm || elmBinaryName;
+
+  try {
+    return runCompiler(sources, optionsWithDefaults, pathToElm);
+  } catch (err) {
+    throw compilerErrorToString(err, pathToElm);
+  }
+}
+
+function compile(sources, options) {
+  var optionsWithDefaults = prepareOptions(options, options.spawn || spawn);
+  var pathToElm = options.pathToElm || elmBinaryName;
+
+
+  try {
+    return runCompiler(sources, optionsWithDefaults, pathToElm)
+      .on('error', function (err) { throw (err); });
+  } catch (err) {
+    throw compilerErrorToString(err, pathToElm);
+  }
+}
+
+function getSuffix(outputPath, defaultSuffix) {
+  if (outputPath) {
+    return path.extname(outputPath) || defaultSuffix;
+  } else {
+    return defaultSuffix;
+  }
+}
+
+// write compiled Elm to a string output
+// returns a Promise which will contain a Buffer of the text
+// If you want html instead of js, use options object to set
+// output to a html file instead
+// creates a temp file and deletes it after reading
+function compileToString(sources, options) {
+  var suffix = getSuffix(options.output, '.js');
+  return new Promise(function (resolve, reject) {
+      temp.open({ suffix: suffix }, function (err, info) {
+          if (err) {
+              return reject(err);
+          }
+          options.output = info.path;
+          options.processOpts = { stdio: 'inherit' };
+          var compiler;
+          try {
+              compiler = compile(sources, options);
+          }
+          catch (compileError) {
+              return reject(compileError);
+          }
+          compiler.on("close", function (exitCode) {
+              if (exitCode !== 0) {
+                  return reject('Compilation failed');
+              }
+              else if (options.verbose) {
+                  console.log(output);
+              }
+              fs.readFile(info.path, { encoding: "utf8" }, function (err, data) {
+                  return err ? reject(err) : resolve(data);
+              });
+          });
+      });
+  });
+}
+
+
+function compileToStringSync(sources, options) {
+  const suffix = getSuffix(options.output, '.js');
+
+  const file = temp.openSync({ suffix });
+  options.output = file.path;
+  compileSync(sources, options);
+
+  return fs.readFileSync(file.path, { encoding: "utf8" });
+}
+
+// Converts an object of key/value pairs to an array of arguments suitable
+// to be passed to child_process.spawn for elm-make.
+function compilerArgsFromOptions(options) {
+  return _.flatten(_.map(options, function (value, opt) {
+    if (value) {
+      switch (opt) {
+        case "help": return ["--help"];
+        case "output": return ["--output", value];
+        case "report": return ["--report", value];
+        case "debug": return ["--debug"];
+        case "docs": return ["--docs", value];
+        case "optimize": return ["--optimize"];
+        case "runtimeOptions": return [].concat(["+RTS"], value, ["-RTS"]);
+        default:
+          if (supportedOptions.indexOf(opt) === -1) {
+            if (opt === "yes") {
+              throw new Error('node-elm-compiler received the `yes` option, but that was removed in Elm 0.19. Try re-running without passing the `yes` option.');
+            } else if (opt === "warn") {
+              throw new Error('node-elm-compiler received the `warn` option, but that was removed in Elm 0.19. Try re-running without passing the `warn` option.');
+            } else if (opt === "pathToMake") {
+              throw new Error('node-elm-compiler received the `pathToMake` option, but that was renamed to `pathToElm` in Elm 0.19. Try re-running after renaming the parameter to `pathToElm`.');
+            } else {
+              throw new Error('node-elm-compiler was given an unrecognized Elm compiler option: ' + opt);
+            }
+          }
+
+          return [];
+      }
+    } else {
+      return [];
+    }
+  }));
+}
+
+module.exports = {
+  compile: compile,
+  compileSync: compileSync,
+  compileWorker: require("./worker")(compile),
+  compileToString: compileToString,
+  compileToStringSync: compileToStringSync,
+  findAllDependencies: findAllDependencies,
+  _prepareProcessArgs: prepareProcessArgs
+};

--- a/generator/node-elm-compiler/worker.js
+++ b/generator/node-elm-compiler/worker.js
@@ -1,0 +1,128 @@
+var temp = require("temp").track();
+var path = require("path");
+var jsEmitterFilename = "emitter.js";
+
+var KNOWN_MODULES =
+  [
+    "fullscreen",
+    "embed",
+    "worker",
+    "Basics",
+    "Maybe",
+    "List",
+    "Array",
+    "Char",
+    "Color",
+    "Transform2D",
+    "Text",
+    "Graphics",
+    "Debug",
+    "Result",
+    "Task",
+    "Signal",
+    "String",
+    "Dict",
+    "Json",
+    "Regex",
+    "VirtualDom",
+    "Html",
+    "Css"
+  ];
+
+
+// elmModuleName is optional, and is by default inferred based on the filename.
+module.exports = function (compile) {
+  return function (projectRootDir, modulePath, moduleName, workerArgs) {
+    var originalWorkingDir = process.cwd();
+    process.chdir(projectRootDir);
+
+    return createTmpDir()
+      .then(function (tmpDirPath) {
+        var dest = path.join(tmpDirPath, jsEmitterFilename);
+
+        return compileEmitter(compile, modulePath, { output: dest })
+          .then(function () { return runWorker(dest, moduleName, workerArgs) });
+      })
+      .then(function (worker) {
+        process.chdir(originalWorkingDir);
+        return worker;
+      })
+      .catch(function (err) {
+        process.chdir(originalWorkingDir);
+        throw Error(err);
+      });
+  };
+};
+
+function createTmpDir() {
+  return new Promise(function (resolve, reject) {
+    temp.mkdir("node-elm-compiler", function (err, tmpDirPath) {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(tmpDirPath);
+      }
+    });
+  });
+}
+
+function suggestModulesNames(Elm) {
+  return Object.keys(Elm).filter(function (key) {
+    return KNOWN_MODULES.indexOf(key) === -1;
+  })
+}
+
+function missingEntryModuleMessage(moduleName, Elm) {
+  var errorMessage = "I couldn't find the entry module " + moduleName + ".\n";
+  var suggestions = suggestModulesNames(Elm);
+
+  if (suggestions.length > 1) {
+    errorMessage += "\nMaybe you meant one of these: " + suggestions.join(",");
+  } else if (suggestions.length === 1) {
+    errorMessage += "\nMaybe you meant: " + suggestions;
+  }
+
+  errorMessage += "\nYou can pass me a different module to use with --module=<moduleName>";
+
+  return errorMessage;
+}
+
+function noPortsMessage(moduleName) {
+  var errorMessage = "The module " + moduleName + " doesn't expose any ports!\n";
+
+  errorMessage += "\n\nTry adding something like";
+  errorMessage += "port foo : Value\nport foo =\n    someValue\n\nto " + moduleName + "!";
+
+  return errorMessage.trim();
+}
+
+function runWorker(jsFilename, moduleName, workerArgs) {
+  return new Promise(function (resolve, reject) {
+    var Elm = require(jsFilename).Elm;
+
+    if (!(moduleName in Elm)) {
+      return reject(missingEntryModuleMessage(moduleName, Elm));
+    }
+
+    var worker = Elm[moduleName].init(workerArgs);
+
+    if (Object.keys(worker.ports).length === 0) {
+      return reject(noPortsMessage(moduleName));
+    }
+
+    return resolve(worker);
+  });
+}
+
+function compileEmitter(compile, src, options) {
+  return new Promise(function (resolve, reject) {
+    compile(src, options)
+      .on("close", function (exitCode) {
+        if (exitCode === 0) {
+          resolve(exitCode);
+        } else {
+          reject("Errored with exit code " + exitCode);
+        }
+      })
+  });
+}

--- a/generator/src/compile-elm.js
+++ b/generator/src/compile-elm.js
@@ -1,4 +1,4 @@
-const { compileToString } = require("node-elm-compiler");
+const { compileToString } = require("../node-elm-compiler/index.js");
 XMLHttpRequest = require("xhr2");
 
 module.exports = runElm;

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "html-webpack-plugin": "^4.0.0-beta.11",
     "imagemin-mozjpeg": "^8.0.0",
     "imagemin-webpack-plugin": "^2.4.2",
-    "node-elm-compiler": "^5.0.4",
     "node-sass": "^4.12.0",
     "prerender-spa-plugin": "^3.4.0",
     "sass-loader": "^8.0.0",
@@ -49,7 +48,11 @@
     "webpack-hot-middleware": "^2.25.0",
     "webpack-merge": "^4.2.1",
     "workbox-webpack-plugin": "^4.3.1",
-    "xhr2": "^0.2.0"
+    "xhr2": "^0.2.0",
+    "cross-spawn": "6.0.5",
+    "find-elm-dependencies": "2.0.2",
+    "lodash": "4.17.15",
+    "temp": "^0.9.0"
   },
   "devDependencies": {
     "@types/chokidar": "^2.1.3",


### PR DESCRIPTION
Fixes #66.

This change forks the node-elm-compiler using a suggested fix from https://github.com/rtfeldman/node-elm-compiler/issues/91#issuecomment-583363707