### PR TITLE
Fix Windows path separator bug

### DIFF
--- a/generator/src/generate-records.js
+++ b/generator/src/generate-records.js
@@ -41,9 +41,9 @@ function unpackFile() {
 function relativeImagePath(imageFilepath) {
   var pathFragments = imageFilepath;
   //remove extesion and split into fragments
-  const fragmentsWithExtension = pathFragments.split(path.sep);
+  const fragmentsWithExtension = pathFragments.split('/');
   fragmentsWithExtension.splice(0, 1);
-  pathFragments = pathFragments.replace(/\.[^/.]+$/, "").split(path.sep);
+  pathFragments = pathFragments.replace(/\.[^/.]+$/, "").split('/');
   pathFragments.splice(0, 1);
   const fullPath = imageFilepath;
   var relative = imageFilepath.slice(dir.length - 1);
@@ -69,7 +69,7 @@ function generate(scanned) {
   for (var i = 0; i < scanned.length; i++) {
     var pathFragments = scanned[i].path;
     //remove extesion and split into fragments
-    pathFragments = pathFragments.replace(/\.[^/.]+$/, "").split(path.sep);
+    pathFragments = pathFragments.replace(/\.[^/.]+$/, "").split('/');
     const is404 = pathFragments.length == 1 && pathFragments[0] == "404";
     const ext = path.extname(scanned[i].path);
 

--- a/generator/src/generate-records.js
+++ b/generator/src/generate-records.js
@@ -5,6 +5,9 @@ const glob = require("glob");
 const fs = require("fs");
 const parseFrontmatter = require("./frontmatter.js");
 
+// Because we use node-glob, we must use `/` as a separator on all platforms. See https://github.com/isaacs/node-glob#windows
+const PATH_SEPARATOR = '/';
+
 module.exports = function wrapper() {
   return generate(scan());
 };
@@ -41,9 +44,9 @@ function unpackFile() {
 function relativeImagePath(imageFilepath) {
   var pathFragments = imageFilepath;
   //remove extesion and split into fragments
-  const fragmentsWithExtension = pathFragments.split('/');
+  const fragmentsWithExtension = pathFragments.split(PATH_SEPARATOR);
   fragmentsWithExtension.splice(0, 1);
-  pathFragments = pathFragments.replace(/\.[^/.]+$/, "").split('/');
+  pathFragments = pathFragments.replace(/\.[^/.]+$/, "").split(PATH_SEPARATOR);
   pathFragments.splice(0, 1);
   const fullPath = imageFilepath;
   var relative = imageFilepath.slice(dir.length - 1);
@@ -69,7 +72,7 @@ function generate(scanned) {
   for (var i = 0; i < scanned.length; i++) {
     var pathFragments = scanned[i].path;
     //remove extesion and split into fragments
-    pathFragments = pathFragments.replace(/\.[^/.]+$/, "").split('/');
+    pathFragments = pathFragments.replace(/\.[^/.]+$/, "").split(PATH_SEPARATOR);
     const is404 = pathFragments.length == 1 && pathFragments[0] == "404";
     const ext = path.extname(scanned[i].path);
 


### PR DESCRIPTION
This should fix #81 bug. The problem was that OS path separator was used to split file paths, however as paths are listed through `glob` lib which is platform agnostic in terms of the output scan paths and always separates file paths with `/`: [see details here](https://github.com/isaacs/node-glob#windows).