### PR TITLE
Fix static folder destination on Windows and clean up its implementation

### DIFF
--- a/generator/src/develop.js
+++ b/generator/src/develop.js
@@ -151,11 +151,10 @@ function webpackOptions(
       new AddFilesPlugin(),
       new CopyPlugin([
         {
-          from: "static/**/*",
-          transformPath(targetPath, absolutePath) {
-            // TODO this is a hack... how do I do this with proper config of `to` or similar?
-            return targetPath.substring(targetPath.indexOf("/") + 1);
-          }
+          // from inside the static folder
+          context: "static/",
+          // copy everything
+          from: "**/*",
         }
       ]),
       new CopyPlugin([


### PR DESCRIPTION
On Windows, a file in static/file.txt was put into dist/static/file.txt instead of dist/file.txt.

This was because we cut off everything before the first "/" in the target path string, but Windows separates folders with "\".

Instead, we can use the somewhat hidden context feature from the CopyPlugin to get rid of the static/ prefix. See https://webpack.js.org/plugins/copy-webpack-plugin/#from-is-a-glob