### PR TITLE
Add woff extension to file-loader

### DIFF
--- a/generator/src/develop.js
+++ b/generator/src/develop.js
@@ -320,7 +320,7 @@ function webpackOptions(
           ]
         },
         {
-          test: /\.(ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+          test: /\.(woff(2)?|ttf|eot|svg)(\?v=[0-9]\.[0-9]\.[0-9])?$/,
           exclude: [/elm-stuff/, /node_modules/],
           loader: require.resolve("file-loader")
         }


### PR DESCRIPTION
This PR adds the `woff` extension to the file-loader in develop.js. Adding the extension fixes the following error when referencing .woff fonts in CSS files:

```
Module parse failed: Unexpected character '' (1:4)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file.
```

