### PR TITLE
Path error prefix

### DIFF
--- a/src/Pages/ContentCache.elm
+++ b/src/Pages/ContentCache.elm
@@ -133,7 +133,7 @@ createBuildError path decodeError =
     { title = "Metadata Decode Error"
     , message =
         [ Terminal.text "I ran into a problem when parsing the metadata for the page with this path: "
-        , Terminal.text (String.join "/" path)
+        , Terminal.text ("/" ++ String.join "/" path)
         , Terminal.text "\n\n"
         , Terminal.text decodeError
         ]

--- a/tests/StaticHttpRequestsTests.elm
+++ b/tests/StaticHttpRequestsTests.elm
@@ -670,7 +670,7 @@ Body: """)
                         |> expectError
                             [ """-- METADATA DECODE ERROR ----------------------------------------------------- elm-pages
 
-I ran into a problem when parsing the metadata for the page with this path: 
+I ran into a problem when parsing the metadata for the page with this path: /
 
 Found an unhandled HTML tag in markdown doc."""
                             ]


### PR DESCRIPTION
As described in #103, the root path is currently displayed as the empty string, which is confusing.

We do not currenlty have access to the content file's path in that module, so we can't show the path to the erroneous file. But this fix should prevent confusion around errors on the root index file.