### PR TITLE
Fix outdated `metaName` doc

### DIFF
--- a/src/Head.elm
+++ b/src/Head.elm
@@ -345,10 +345,7 @@ metaProperty property content =
 
 {-| Example:
 
-    metaName
-        [ ( "name", "twitter:card" )
-        , ( "content", "summary_large_image" )
-        ]
+    Head.metaName "twitter:card" (Head.raw "summary_large_image")
 
 Results in `<meta name="twitter:card" content="summary_large_image" />`
 


### PR DESCRIPTION
Hey, while using this package I noticed the `metaName` doc had a different type signature than the automatically generated one. Using the current docs example resulted in an error.

I assumed it now works just like `metaProperty`.  I tested it locally, and that seems to work.

👋