### PR TITLE
Load content.json from correct pathname

### DIFF
--- a/index.js
+++ b/index.js
@@ -204,7 +204,11 @@ function prefetchIfNeeded(/** @type {HTMLAnchorElement} */ target) {
       link.setAttribute("as", "fetch");
 
       link.setAttribute("rel", "prefetch");
-      link.setAttribute("href", origin + target.pathname + "/content.json");
+      if (target.pathname.slice(-1) === "/") {
+        link.setAttribute("href", origin + target.pathname + "content.json");
+      } else {
+        link.setAttribute("href", origin + target.pathname + "/content.json");
+      }
       document.head.appendChild(link);
     }
   }


### PR DESCRIPTION
When prefetching `content.json` files it can become doubled slashed `localhost//content.json` when the href ends with slash.