### PR TITLE
Handle missing trailing slashes in dev server

### DIFF
--- a/generator/src/cli.js
+++ b/generator/src/cli.js
@@ -115,7 +115,7 @@ function normalizeUrl(pagePath) {
     pagePath = "/" + pagePath;
   }
   const isRoot = pagePath === "/";
-  if (pagePath.endsWith("/") && !isRoot) {
+  if (!pagePath.endsWith("/") && !isRoot) {
     pagePath = pagePath.slice(0, pagePath.length);
   }
   return pagePath;

--- a/generator/src/cli.js
+++ b/generator/src/cli.js
@@ -114,9 +114,7 @@ function normalizeUrl(pagePath) {
   if (!pagePath.startsWith("/")) {
     pagePath = "/" + pagePath;
   }
-  if (!pagePath.endsWith("/")) {
-    pagePath = pagePath + "/";
-  }
+  pagePath = pagePath.replace(/\/?$/, "");
   return pagePath;
 }
 

--- a/generator/src/cli.js
+++ b/generator/src/cli.js
@@ -115,8 +115,8 @@ function normalizeUrl(pagePath) {
     pagePath = "/" + pagePath;
   }
   const isRoot = pagePath === "/";
-  if (!pagePath.endsWith("/") && !isRoot) {
-    pagePath = pagePath.slice(0, pagePath.length);
+  if (pagePath.endsWith("/") && !isRoot) {
+    pagePath = pagePath.slice(0, pagePath.length - 1);
   }
   return pagePath;
 }

--- a/generator/src/cli.js
+++ b/generator/src/cli.js
@@ -114,7 +114,10 @@ function normalizeUrl(pagePath) {
   if (!pagePath.startsWith("/")) {
     pagePath = "/" + pagePath;
   }
-  pagePath = pagePath.replace(/\/?$/, "");
+  const isRoot = pagePath === "/";
+  if (pagePath.endsWith("/") && !isRoot) {
+    pagePath = pagePath.slice(0, pagePath.length);
+  }
   return pagePath;
 }
 


### PR DESCRIPTION
Previously when using for example `elm-pages dev --base sub`, the dev server would correctly rewrite `localhost:1234/sub/`, but not `localhost:1234/sub` (missing trailing slash).

This PR makes the dev server agnostic towards trailing slashes.

# Reproduction of the issue
1. `npm start -- --base sub`
2. Visit localhost:1234/sub/ (it works)
3. Visit localhost:1234/sub (it doesn't work)