### PR TITLE
fix 07-data-sources doc

### DIFF
--- a/examples/docs/content/docs/07-data-sources.md
+++ b/examples/docs/content/docs/07-data-sources.md
@@ -2,7 +2,7 @@
 description: TODO
 ---
 
-# `DataSource`s
+# DataSources
 
 It doesn't matter _where_ a `DataSource` came from.
 


### PR DESCRIPTION
As I was reading the documentation, I noticed that only the Data Sources chapter heading had a different color than the other headings. I felt something was wrong with this and thought it was a typo, so I corrected the markdown, but if this is the intended notation, please reject this pull request!

## Before
![2021-09-25 033921](https://user-images.githubusercontent.com/43922475/134724914-f505b01b-e12d-46a0-b42f-2d30577ef400.jpg)

## After
![2021-09-25 033857](https://user-images.githubusercontent.com/43922475/134724899-2193e950-1382-4fdb-8ebc-b84a0b83ee75.jpg)
