### PR TITLE
Clarify hardcoded values are not masked.

### DIFF
--- a/src/Pages/Secrets.elm
+++ b/src/Pages/Secrets.elm
@@ -57,6 +57,8 @@ type alias Value value =
 {-| Hardcode a secret value. Or, this can be used to start a pipeline-style value with several different secrets (see
 the example at the top of this page).
 
+Warning: a hardcoded value is not protected by masking! Make sure to to use `Secrets.with` to fetch sentitive values from environment variables.
+
     import Pages.Secrets as Secrets
 
     Secrets.succeed "hardcoded-secret"


### PR DESCRIPTION
I mistakenly used `Secrets.succeed` to directly wrap a secret not realising that doesn't protect it!

So I've added the note that I think would have helped me better understand this, and might help others who scan the docs fast without reading carefully. 😅 