### PR TITLE
Fix issues with trailing slashes in the base

### DIFF
--- a/generator/src/basepath-middleware.js
+++ b/generator/src/basepath-middleware.js
@@ -31,7 +31,7 @@ module.exports = function baseMiddleware(base) {
       res.statusCode = 404;
       res.end(
         `The server is configured with a public base URL of ${base} - ` +
-          `did you mean to visit ${base}${url.slice(1)} instead?`
+          `did you mean to visit ${base}/${url.slice(1)} instead?`
       );
       return;
     }

--- a/generator/src/basepath-middleware.js
+++ b/generator/src/basepath-middleware.js
@@ -3,6 +3,9 @@ const parseUrl = require("url").parse;
 // this middleware is only active when (config.base !== '/')
 
 module.exports = function baseMiddleware(base) {
+  // We want to detect the base with and without a trailing slash.
+  const baseRegExp= new RegExp(base + "/?");
+  
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteBaseMiddleware(req, res, next) {
     const url = req.url;
@@ -10,9 +13,9 @@ module.exports = function baseMiddleware(base) {
     const path = parsed.pathname || "/";
 
     if (path.startsWith(base)) {
-      // rewrite url to remove base.. this ensures that other middleware does
+      // rewrite url to remove base. this ensures that other middleware does
       // not need to consider base being prepended or not
-      req.url = url.replace(base, "/");
+      req.url = url.replace(baseRegExp, "/");
       return next();
     }
 

--- a/generator/src/basepath-middleware.js
+++ b/generator/src/basepath-middleware.js
@@ -3,6 +3,8 @@
 module.exports = function baseMiddleware(base) {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteBaseMiddleware(req, res, next) {
+    // `req.url` only contains the path, since that is what gets passed in the HTTP request.
+    // See https://nodejs.org/api/http.html#http_message_url
     const path = req.url;
 
     // We want to detect the base at the beginning, hence the `^`,
@@ -25,7 +27,7 @@ module.exports = function baseMiddleware(base) {
     } else if (req.headers.accept && req.headers.accept.includes("text/html")) {
       // non-based page visit
       res.statusCode = 404;
-      const suggestionUrl = `${base}/${.slice(1)}`;
+      const suggestionUrl = `${base}/${path.slice(1)}`;
       res.end(
         `The server is configured with a public base URL of ${base} - ` +
         `did you mean to visit ${suggestionUrl} instead?`

--- a/generator/src/basepath-middleware.js
+++ b/generator/src/basepath-middleware.js
@@ -1,5 +1,3 @@
-const parseUrl = require("url").parse;
-
 // this middleware is only active when (config.base !== '/')
 
 module.exports = function baseMiddleware(base) {
@@ -9,7 +7,7 @@ module.exports = function baseMiddleware(base) {
   // Keep the named function. The name is visible in debug logs via `DEBUG=connect:dispatcher ...`
   return function viteBaseMiddleware(req, res, next) {
     const url = req.url;
-    const parsed = parseUrl(url);
+    const parsed = new URL(url);
     const path = parsed.pathname || "/";
 
     if (path.startsWith(base)) {

--- a/generator/src/cli.js
+++ b/generator/src/cli.js
@@ -108,22 +108,18 @@ function clearHttpAndPortCache() {
 }
 
 /**
- * @param {string} pagePath
+ * @param {string} rawPagePath
  */
-function normalizeUrl(pagePath) {
-  if (!pagePath.startsWith("/")) {
-    pagePath = "/" + pagePath;
-  }
+function normalizeUrl(rawPagePath) {
+  const segments = rawPagePath.split("/")
+      // Filter out all empty segments.
+      .filter(segment => segment.length != 0);
 
-  // Remove any trailing slash.
+  // Do not add a trailing slash.
   // The core issue is that `/base` is a prefix of `/base/`, but
   // `/base/` is not a prefix of `/base`, which can later lead to issues
   // with detecting whether the path contains the base.
-  if (pagePath.endsWith("/")) {
-    pagePath = pagePath.substring(0, -1);
-  }
-
-  return pagePath;
+  return `/${segments.join("/")}`
 }
 
 main();

--- a/generator/src/cli.js
+++ b/generator/src/cli.js
@@ -114,9 +114,15 @@ function normalizeUrl(pagePath) {
   if (!pagePath.startsWith("/")) {
     pagePath = "/" + pagePath;
   }
-  if (!pagePath.endsWith("/")) {
-    pagePath = pagePath + "/";
+
+  // Remove any trailing slash.
+  // The core issue is that `/base` is a prefix of `/base/`, but
+  // `/base/` is not a prefix of `/base`, which can later lead to issues
+  // with detecting whether the path contains the base.
+  if (pagePath.endsWith("/")) {
+    pagePath = pagePath.substring(0, -1);
   }
+
   return pagePath;
 }
 


### PR DESCRIPTION
I revisited #208 and realized that I could simplify it. Additionally, this solves the issue where the index page is not rendered correctly (#217).

To summarize, previously when running `elm-pages dev --base sub`, you would be able to open `localhost:1234/sub/` but not `localhost:1234/sub`. This PR changes the `basepath-middleware.js`'s check to make the trailing slash optional, and make `localhost:1234/sub` work.

For that we also need to remove the slash from the base path when normalizing it in `cli.js`. A side effect of this is that the index page now works when running `elm-pages build --base path`. Previously the page would render, but then its content was an error message that the page was an invalid route (#217). This was probably to due a faulty prefix check: The page's path is determined to be `/sub`, but the route probably tries to remove the base `/sub/` which is not a prefix of `/sub`. Therefore the route is not correctly determined, because the base is kept. By normalizing the base to not have a trailing slash, this prefix check is fixed and when building the site the index page now is rendered correctly.