### PR TITLE
Expose base URL

### DIFF
--- a/generator/src/generate-template-module-connector.js
+++ b/generator/src/generate-template-module-connector.js
@@ -677,7 +677,7 @@ mapBoth : (a -> b) -> (c -> d) -> ( a, c, e ) -> ( b, d, e )
 mapBoth fnA fnB ( a, b, c ) =
     ( fnA a, fnB b, c )
 `,
-    routesModule: `module Route exposing (Route(..), link, matchers, routeToPath, toLink, urlToRoute, toPath)
+    routesModule: `module Route exposing (baseUrlAsPath, Route(..), link, matchers, routeToPath, toLink, urlToRoute, toPath)
 
 {-|
 


### PR DESCRIPTION
As far as I can tell, I currently have no way of knowing what base URL is set. This PR exposes that information.

While `Route.toPath` prepends the base, I could not find a way to prepend the base to asset paths such as images. This is required for making elm-pages work on subpaths, for example when using GitHub Pages.

The reason I only exposed `baseAsPath` is that it's much easier to deal with than the `baseUrl` which may contain slashes. We could consider exposing `baseUrl` too.