### PR TITLE
Add --debug flag for elm-pages dev

### DIFF
--- a/generator/src/build.js
+++ b/generator/src/build.js
@@ -225,13 +225,13 @@ function elmOptimizeLevel2(elmEntrypointPath, outputPath, cwd) {
  */
 async function spawnElmMake(options, elmEntrypointPath, outputPath, cwd) {
   if (options.debug) {
-    await runElmMake(elmEntrypointPath, outputPath, cwd);
+    await runElmMake(options, elmEntrypointPath, outputPath, cwd);
   } else {
     await elmOptimizeLevel2(elmEntrypointPath, outputPath, cwd);
   }
 }
 
-function runElmMake(elmEntrypointPath, outputPath, cwd) {
+function runElmMake(options, elmEntrypointPath, outputPath, cwd) {
   return new Promise(async (resolve, reject) => {
     const subprocess = spawnCallback(
       `elm`,
@@ -240,7 +240,7 @@ function runElmMake(elmEntrypointPath, outputPath, cwd) {
         elmEntrypointPath,
         "--output",
         outputPath,
-        "--debug",
+        ...(options.debug ? ["--debug"] : []),
         "--report",
         "json",
       ],

--- a/generator/src/cli.js
+++ b/generator/src/cli.js
@@ -43,6 +43,7 @@ async function main() {
     .command("dev")
     .description("start a dev server")
     .option("--port <number>", "serve site at localhost:<port>", "1234")
+    .option("--debug", "Run elm make with --debug")
     .option(
       "--keep-cache",
       "Preserve the HTTP and JS Port cache instead of deleting it on server start"

--- a/generator/src/compile-elm.js
+++ b/generator/src/compile-elm.js
@@ -10,9 +10,9 @@ const pathToClientElm = path.join(
   "browser-elm.js"
 );
 
-async function spawnElmMake(elmEntrypointPath, outputPath, cwd) {
+async function spawnElmMake(options, elmEntrypointPath, outputPath, cwd) {
   const fullOutputPath = cwd ? path.join(cwd, outputPath) : outputPath;
-  await runElm(elmEntrypointPath, outputPath, cwd);
+  await runElm(options, elmEntrypointPath, outputPath, cwd);
 
   await fs.promises.writeFile(
     fullOutputPath,
@@ -35,8 +35,12 @@ async function spawnElmMake(elmEntrypointPath, outputPath, cwd) {
   );
 }
 
-async function compileElmForBrowser() {
-  await runElm("./.elm-pages/TemplateModulesBeta.elm", pathToClientElm);
+async function compileElmForBrowser(options) {
+  await runElm(
+    options,
+    "./.elm-pages/TemplateModulesBeta.elm",
+    pathToClientElm
+  );
   return fs.promises.writeFile(
     "./.elm-pages/cache/elm.js",
     inject(await fs.promises.readFile(pathToClientElm, "utf-8"))
@@ -46,9 +50,10 @@ async function compileElmForBrowser() {
 /**
  * @param {string} elmEntrypointPath
  * @param {string} outputPath
- * @param {string} [ cwd ]
+ * @param {string} [cwd]
+ * @param {{ debug: boolean; }} options
  */
-async function runElm(elmEntrypointPath, outputPath, cwd) {
+async function runElm(options, elmEntrypointPath, outputPath, cwd) {
   const startTime = Date.now();
   return new Promise((resolve, reject) => {
     const child = spawnCallback(
@@ -58,7 +63,7 @@ async function runElm(elmEntrypointPath, outputPath, cwd) {
         elmEntrypointPath,
         "--output",
         outputPath,
-        "--debug",
+        ...(options.debug ? ["--debug"] : []),
         "--report",
         "json",
       ],

--- a/generator/src/dev-server.js
+++ b/generator/src/dev-server.js
@@ -21,7 +21,7 @@ const baseMiddleware = require("./basepath-middleware.js");
 const devcert = require("devcert");
 
 /**
- * @param {{ port: string; base: string; https: boolean; }} options
+ * @param {{ port: string; base: string; https: boolean; debug: boolean; }} options
  */
 async function start(options) {
   let threadReadyQueue = [];
@@ -59,8 +59,8 @@ async function start(options) {
     console.error(error);
     process.exit(1);
   }
-  let clientElmMakeProcess = compileElmForBrowser();
-  let pendingCliCompile = compileCliApp();
+  let clientElmMakeProcess = compileElmForBrowser(options);
+  let pendingCliCompile = compileCliApp(options);
   watchElmSourceDirs(true);
 
   async function setup() {
@@ -105,8 +105,9 @@ async function start(options) {
     watcher.add("./port-data-source.js");
   }
 
-  async function compileCliApp() {
+  async function compileCliApp(options) {
     await spawnElmMake(
+      options,
       ".elm-pages/TemplateModulesBeta.elm",
       "elm.js",
       "elm-stuff/elm-pages/"
@@ -154,8 +155,8 @@ async function start(options) {
         if (needToRerunCodegen(eventName, pathThatChanged)) {
           try {
             await codegen.generate(options.base);
-            clientElmMakeProcess = compileElmForBrowser();
-            pendingCliCompile = compileCliApp();
+            clientElmMakeProcess = compileElmForBrowser(options);
+            pendingCliCompile = compileCliApp(options);
 
             Promise.all([clientElmMakeProcess, pendingCliCompile])
               .then(() => {
@@ -180,8 +181,8 @@ async function start(options) {
           clientElmMakeProcess = Promise.reject(errorJson);
           pendingCliCompile = Promise.reject(errorJson);
         } else {
-          clientElmMakeProcess = compileElmForBrowser();
-          pendingCliCompile = compileCliApp();
+          clientElmMakeProcess = compileElmForBrowser(options);
+          pendingCliCompile = compileCliApp(options);
         }
 
         Promise.all([clientElmMakeProcess, pendingCliCompile])


### PR DESCRIPTION
The default is now with no --debug like in elm make.