### PR TITLE
Expose Head.node to allow creating a custom Tag

### DIFF
--- a/src/Head.elm
+++ b/src/Head.elm
@@ -1,5 +1,5 @@
 module Head exposing
-    ( Tag, metaName, metaProperty, metaRedirect
+    ( Tag, node, metaName, metaProperty, metaRedirect
     , rssLink, sitemapLink, rootLanguage
     , structuredData
     , AttributeValue


### PR DESCRIPTION
Currently its not possible to create your own instance of a Tag, exposing the Head.node function allows this feature.