### PR TITLE
Reflect new DataSource.File API in example

### DIFF
--- a/examples/docs/content/docs/07-data-sources.md
+++ b/examples/docs/content/docs/07-data-sources.md
@@ -45,7 +45,7 @@ In fact, let's combine our library of authors from 3 different `DataSource`s.
 ```elm
 authorsFromFile : DataSource (List Author)
 authorsFromFile =
-    DataSource.File.read "data/authors.json"
+    DataSource.File.rawFile "data/authors.json"
         authorsDecoder
 
 allAuthors : DataSource (List Author)

--- a/examples/docs/content/docs/07-data-sources.md
+++ b/examples/docs/content/docs/07-data-sources.md
@@ -45,7 +45,7 @@ In fact, let's combine our library of authors from 3 different `DataSource`s.
 ```elm
 authorsFromFile : DataSource (List Author)
 authorsFromFile =
-    DataSource.File.rawFile "data/authors.json"
+    DataSource.File.jsonFile "data/authors.json"
         authorsDecoder
 
 allAuthors : DataSource (List Author)


### PR DESCRIPTION
I tried copying this example and found the API has since changed. 

Commit 1: Change `read` to `rawFile`.
Commit 2: Change `rawFile` to `jsonFile` since argument seems to be json