### PR TITLE
Prevent error message when port-data-source.js is missing.

### DIFF
--- a/generator/src/dev-server.js
+++ b/generator/src/dev-server.js
@@ -139,6 +139,7 @@ async function start(options) {
   });
   try {
     await fs.statSync("./port-data-source.js");
+    await fs.statSync("./port-data-source.ts");
     // If the file does not exist, an exception will be thrown and we skip the build.
   esbuild
     .build({

--- a/generator/src/dev-server.js
+++ b/generator/src/dev-server.js
@@ -137,10 +137,21 @@ async function start(options) {
     base: options.base,
     ...viteConfig,
   });
+
+  let jsExists = false;
   try {
-    await fs.statSync("./port-data-source.js");
-    await fs.statSync("./port-data-source.ts");
-    // If the file does not exist, an exception will be thrown and we skip the build.
+    fs.statSync("./port-data-source.js");
+    jsExists = true;
+  } catch (e) { }
+
+  let tsExists = false;
+  try {
+    fs.statSync("./port-data-source.ts");
+    tsExists = true;
+  } catch (e) { }
+
+  if (jsExists || tsExists) {
+    try {
   esbuild
     .build({
       entryPoints: ["./port-data-source"],
@@ -177,13 +188,6 @@ async function start(options) {
       console.error("Failed to start port-data-source watcher", error);
     });
   } catch (e) {
-    if (e.code == "ENOENT") {
-      console.warn(
-        kleur.yellow(
-          "No `port-data-source.js` file found."
-        )
-      );
-    } else {
       throw e;
     }
   }

--- a/generator/src/dev-server.js
+++ b/generator/src/dev-server.js
@@ -137,6 +137,9 @@ async function start(options) {
     base: options.base,
     ...viteConfig,
   });
+  try {
+    await fs.statSync("./port-data-source.js");
+    // If the file does not exist, an exception will be thrown and we skip the build.
   esbuild
     .build({
       entryPoints: ["./port-data-source"],
@@ -172,6 +175,17 @@ async function start(options) {
     .catch((error) => {
       console.error("Failed to start port-data-source watcher", error);
     });
+  } catch (e) {
+    if (e.code == "ENOENT") {
+      console.warn(
+        kleur.yellow(
+          "No `port-data-source.js` file found."
+        )
+      );
+    } else {
+      throw e;
+    }
+  }
 
   const app = connect()
     .use(timeMiddleware())


### PR DESCRIPTION
When running `npm run start` on the [elm-pages v3 starter repo](https://github.com/dillonkearns/elm-pages-3-alpha-starter), I got an error message about the `port-data-source.js` missing:

```
$ npm run start

> start
> elm-pages dev

No `elm-pages.config.mjs` file found. Using default config.
Failed to start port-data-source watcher Error: Build failed with 2 errors:
error: Could not resolve "./port-data-source"
C:\Users\Johannes\Code\elm-pages-3-alpha-starter\elm-pages\generator\src\dev-server.js:162:65: ERROR: [plugin: example] Cannot read property 'outputs' of undefined
    at failureErrorWithLog (C:\Users\Johannes\Code\elm-pages-3-alpha-starter\node_modules\esbuild\lib\main.js:1599:15)
    at C:\Users\Johannes\Code\elm-pages-3-alpha-starter\node_modules\esbuild\lib\main.js:1245:28
    at processTicksAndRejections (internal/process/task_queues.js:93:5) {
  errors: [
    {
      detail: undefined,
      location: null,
      notes: [],
      pluginName: '',
      text: 'Could not resolve "./port-data-source"'
    },
    {
      pluginName: 'example',
      text: "Cannot read property 'outputs' of undefined",
      location: [Object],
      notes: [Array],
      detail: TypeError: Cannot read property 'outputs' of undefined
          at C:\Users\Johannes\Code\elm-pages-3-alpha-starter\elm-pages\generator\src\dev-server.js:162:66
          at C:\Users\Johannes\Code\elm-pages-3-alpha-starter\node_modules\esbuild\lib\main.js:1036:21
          at runOnEndCallbacks (C:\Users\Johannes\Code\elm-pages-3-alpha-starter\node_modules\esbuild\lib\main.js:1041:11)
          at buildResponseToResult (C:\Users\Johannes\Code\elm-pages-3-alpha-starter\node_modules\esbuild\lib\main.js:1243:7)
          at C:\Users\Johannes\Code\elm-pages-3-alpha-starter\node_modules\esbuild\lib\main.js:1352:14
          at C:\Users\Johannes\Code\elm-pages-3-alpha-starter\node_modules\esbuild\lib\main.js:662:9
          at handleIncomingPacket (C:\Users\Johannes\Code\elm-pages-3-alpha-starter\node_modules\esbuild\lib\main.js:759:9)
          at Socket.readFromStdout (C:\Users\Johannes\Code\elm-pages-3-alpha-starter\node_modules\esbuild\lib\main.js:629:7)
          at Socket.emit (events.js:315:20)
          at addChunk (internal/streams/readable.js:309:12)
    }
  ],
  warnings: []
}
Ran elm make ./.elm-pages/Main.elm in 559ms
Ran elm make .elm-pages/Main.elm in 696ms
elm-pages dev server running at <http://localhost:1234>
```

Since I believe the file is optional, I propose this PR that checks whether it exists. If does not, nothing happens. If the user calls a port data source, they will get an improved error message, if #282 is merged.