### PR TITLE
Fix port data source import on Windows

### DIFF
--- a/generator/src/request-cache.js
+++ b/generator/src/request-cache.js
@@ -54,26 +54,32 @@ function lookupOrPerform(portsFile, mode, rawRequest, hasFsAccess) {
       resolve(responsePath);
     } else {
       let portDataSource = {};
-      let portDataSourceFound = false;
+      let portDataSourceImportError = null;
       try {
+        if (portsFile === undefined)  {
+          throw "missing"
+        }
         const portDataSourcePath = path.join(process.cwd(), portsFile);
         // On Windows, we need cannot use paths directly and instead must use a file:// URL.
         portDataSource = await import(url.pathToFileURL(portDataSourcePath).href);
-        portDataSourceFound = true;
-      } catch (e) {}
+      } catch (e) {
+        portDataSourceImportError = e;
+      }
 
       if (request.url === "elm-pages-internal://port") {
         try {
           const { input, portName } = rawRequest.body.args[0];
 
           if (!portDataSource[portName]) {
-            if (portDataSourceFound) {
-              throw `DataSource.Port.send "${portName}" is not defined. Be sure to export a function with that name from port-data-source.js`;
+            if (portDataSourceImportError === null) {
+              throw `DataSource.Port.send "${portName}" was called, but I couldn't find a function with that name in the port definitions file. Is it exported correctly?`;
+            } else if (portDataSourceImportError === "missing") {
+              throw `DataSource.Port.send "${portName}" was called, but I couldn't find the port definitions file. Be sure to create a 'port-data-source.ts' or 'port-data-source.js' file and maybe restart the dev server.`;
             } else {
-              throw `DataSource.Port.send "${portName}" was called, but I couldn't find a port definitions file. Create a 'port-data-source.ts' or 'port-data-source.js' file and export a ${portName} function.`;
+              throw `DataSource.Port.send "${portName}" was called, but I couldn't import the port definitions file, because of this exception: \`${portDataSourceImportError}\` Are there syntax errors or expections thrown during import?`;
             }
           } else if (typeof portDataSource[portName] !== "function") {
-            throw `DataSource.Port.send "${portName}" is not a function. Be sure to export a function with that name from port-data-source.js`;
+            throw `DataSource.Port.send "${portName}" was called, but it is not a function. Be sure to export a function with that name from port-data-source.js`;
           }
           await fs.promises.writeFile(
             responsePath,

--- a/generator/src/request-cache.js
+++ b/generator/src/request-cache.js
@@ -1,4 +1,5 @@
 const path = require("path");
+const url = require("url");
 const fetch = require("node-fetch");
 const objectHash = require("object-hash");
 const kleur = require("kleur");
@@ -55,7 +56,9 @@ function lookupOrPerform(portsFile, mode, rawRequest, hasFsAccess) {
       let portDataSource = {};
       let portDataSourceFound = false;
       try {
-        portDataSource = await import(path.join(process.cwd(), portsFile));
+        const portDataSourcePath = path.join(process.cwd(), portsFile);
+        // On Windows, we need cannot use paths directly and instead must use a file:// URL.
+        portDataSource = await import(url.pathToFileURL(portDataSourcePath).href);
         portDataSourceFound = true;
       } catch (e) {}
 
@@ -143,7 +146,7 @@ function lookupOrPerform(portsFile, mode, rawRequest, hasFsAccess) {
                 .yellow()
                 .underline(request.url)} Bad HTTP response ${response.status} ${
                 response.statusText
-              }
+                }
 `,
             });
           }


### PR DESCRIPTION
When trying to use a `port-data-source.js` on Windows, I run into another path-related issue:

```
Trace: DataSource.Port.send "imageSources" was called, but I couldn't find a port definitions file. Create a 'port-data-source.ts' or 'port-data-source.js' file and export a imageSources function.
    at C:\Users\Johannes\Code\elm-pages-3-alpha-starter\elm-pages\generator\src\request-cache.js:84:19
```

The cause is that we `import()` the file using an absolute path, but [Windows-style absolute paths do not work and we have to use `file://` URLs instead](https://github.com/nodejs/node/issues/34765#issue-678712830).