### PR TITLE
Fix crash on parse tab in error string

### DIFF
--- a/generator/src/dev-server.js
+++ b/generator/src/dev-server.js
@@ -309,6 +309,7 @@ async function start(options) {
     } catch (error) {
       let isImplicitContractError = false;
       try {
+        error = error.replace("\t", "    ");
         isImplicitContractError = JSON.parse(error).errors.some(
           (errorItem) => errorItem.name === "TemplateModulesBeta"
         );


### PR DESCRIPTION
Just had this weird crash & I couldn't debug it as the error report JSON itself had a tab in it (turns out I had a tab in my source file).

Before the error displayed as:

```
Unexpected error SyntaxError: Unexpected token 	 in JSON at position 393
    at JSON.parse (<anonymous>)
    at handleNavigationRequest (/Users/angusfindlay/Documents/code/angusjf/node_modules/elm-pages/generator/src/dev-server.js:311:40)
```

Now it's displayed as expected

```
-- NO TABS --------------- /Users/angusfindlay/Documents/code/angusjf/src/Page/Page_.elm
I ran into a tab, but tabs are not allowed in Elm files.

303|     div [ css [ Tw.flex, Tw.justify_center, Tw.mb_12 ] ] [ a [ css [Tw.no_underline    ], href "/" ] [ text "home" ] ]
```

Might not even be an issue any more in 3.0 but I thought I might as well flag it!