### PR TITLE
Implement the --optimize CLI option to allow build without elm-optimize-level-2

### DIFF
--- a/generator/src/cli.js
+++ b/generator/src/cli.js
@@ -22,6 +22,15 @@ async function main() {
     .command("build")
     .option("--debug", "Skip terser and run elm make with --debug")
     .option(
+      "--optimize <level>",
+      [
+        "Set the optimization level:",
+        "0 - no optimization",
+        "1 - basic optimizations provided by the Elm compiler",
+        "2 - advanced optimizations provided by Elm Optimize Level 2 (default unless --debug)",
+      ].join("\n")
+    )
+    .option(
       "--base <basePath>",
       "build site to be served under a base path",
       "/"
@@ -32,6 +41,19 @@ async function main() {
     )
     .description("run a full site build")
     .action(async (options) => {
+
+      if (options.optimize !== undefined && options.debug) {
+        console.error("error: The --debug and --optimize options are mutually exclusive.");
+        process.exit(1);
+      }
+      if (options.optimize === undefined) {
+        options.optimize = "2";
+      }
+      if (! ["0", "1", "2"].includes(options.optimize)) {
+        console.error(`error: argument ${options.optimize} for the --optimize option is invalid. Allowed choices are 0, 1, 2.`);
+        process.exit(1);
+      }
+
       if (!options.keepCache) {
         clearHttpAndPortCache();
       }


### PR DESCRIPTION
The rationale and design for this feature are discussed in #288 .