### PR TITLE
Add Head.ResourceHints

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -6,6 +6,7 @@
     "version": "9.0.0",
     "exposed-modules": [
         "Head",
+        "Head.ResourceHints",
         "Head.Seo",
         "ApiRoute",
         "Path",

--- a/examples/docs/src/Site.elm
+++ b/examples/docs/src/Site.elm
@@ -3,6 +3,7 @@ module Site exposing (config)
 import Cloudinary
 import DataSource exposing (DataSource)
 import Head
+import Head.ResourceHints as ResourceHints
 import MimeType
 import Pages.Manifest as Manifest
 import Pages.Url
@@ -36,6 +37,7 @@ head static =
     , Head.appleTouchIcon (Just 192) (cloudinaryIcon MimeType.Png 192)
     , Head.rssLink "/blog/feed.xml"
     , Head.sitemapLink "/sitemap.xml"
+    , ResourceHints.preloadLink "https://fonts.gstatic.com/s/ibmplexmono/v6/-F63fjptAgt5VM-kVkqdyU8n1i8q131nj-o.woff2" (Just ResourceHints.Font) (Just ResourceHints.Anonymous)
     ]
 
 

--- a/src/Head.elm
+++ b/src/Head.elm
@@ -6,6 +6,7 @@ module Head exposing
     , currentPageFullUrl, urlAttribute, raw
     , appleTouchIcon, icon
     , toJson, canonicalLink
+    , ResourceHint(..), resourceHintLink
     )
 
 {-| This module contains low-level functions for building up
@@ -351,6 +352,55 @@ sitemapLink url =
         , ( "type", raw "application/xml" )
         , ( "href", raw url )
         ]
+
+
+{-| Resource hint types that can be passed to Head.resourceHintLink
+-}
+type ResourceHint
+    = DnsPrefetch
+    | Preconnect
+    | Preload
+    | Prefetch
+
+
+{-| Add a resource hint link
+
+Example:
+
+    resourceHintLink Preload "//background.png" (Just (raw "image")) Nothing
+
+```html
+<link rel="preload" href="//background.png" as="image">
+```
+
+You probably want to use Head.ResourceHints rather that this directly.
+
+-}
+resourceHintLink : ResourceHint -> String -> Maybe AttributeValue -> Maybe AttributeValue -> Tag
+resourceHintLink hint href maybeType maybeCrossOrigin =
+    node "link"
+        ([ Just
+            ( "rel"
+            , raw <|
+                case hint of
+                    DnsPrefetch ->
+                        "dns-prefetch"
+
+                    Preconnect ->
+                        "preconnect"
+
+                    Preload ->
+                        "preload"
+
+                    Prefetch ->
+                        "prefetch"
+            )
+         , Just ( "href", raw href )
+         , Maybe.map (Tuple.pair "as") maybeType
+         , Maybe.map (Tuple.pair "crossorigin") maybeCrossOrigin
+         ]
+            |> List.filterMap identity
+        )
 
 
 {-| Example:

--- a/src/Head/ResourceHints.elm
+++ b/src/Head/ResourceHints.elm
@@ -1,0 +1,171 @@
+module Head.ResourceHints exposing
+    ( CrossOrigin(..)
+    , FileType(..)
+    , dnsPrefetchLink
+    , preconnectLink
+    , prefetchLink
+    , preloadLink
+    )
+
+import Head exposing (ResourceHint(..), Tag, raw, resourceHintLink)
+
+
+{-| Possible values for resource hint `crossorigin` attribute
+-}
+type CrossOrigin
+    = Anonymous
+    | UseCredentials
+
+
+{-| Possible values for resource hint `as` attribute
+-}
+type FileType
+    = Audio
+    | Document
+    | Embed
+    | Fetch
+    | Font
+    | Image
+    | Object
+    | Script
+    | Style
+    | Track
+    | Worker
+    | Video
+
+
+{-| Create a dns-prefetch resource hint.
+
+Instructs the browser to perform DNS lookup for domains that will be needed to load external assets.
+
+See: <https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/dns-prefetch>
+
+-}
+dnsPrefetchLink : String -> Tag
+dnsPrefetchLink href =
+    resourceHintLink DnsPrefetch href Nothing Nothing
+
+
+{-| Create a preconnect resource hint
+
+Instructs the browser to establish a connection to a server that will be needed to load external assets.
+
+Example:
+
+    preconnectLink "https://fonts.gstatic.com/" (Just Anonymous)
+
+```html
+<link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin>
+```
+
+See: <https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preconnect>
+
+-}
+preconnectLink : String -> Maybe CrossOrigin -> Tag
+preconnectLink href =
+    resourceHintWithOptionalAttributes Preconnect href Nothing
+
+
+{-| Create a preload resource hint
+
+Instructs the browser to begin downloading an asset that will be needed immediately.
+
+Useful for preventing request waterfalls for images and css loaded via CSS.
+
+Given the following:
+
+```css
+.my-class {
+    background-image: url(/images/background.png);
+}
+```
+
+in an external css file, the browser would normally have to first retrieve and parse the CSS,
+_then_ fetch the background image. Adding a prefetch hint for this will cause the browser to
+begin downloading the image and css concurrently.
+
+Example:
+
+    preloadLink "/images/background.png" (Just Image) Nothing
+
+```html
+<link rel="preload" href="/images/background.png" as="image">
+```
+
+See: <https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/preload>
+
+-}
+preloadLink : String -> Maybe FileType -> Maybe CrossOrigin -> Tag
+preloadLink =
+    resourceHintWithOptionalAttributes Preload
+
+
+{-| Create a prefetch resource hint
+
+Instructs the browser that an asset will likely be needed during the life of this
+page on on a subsequent navigation and to download them with low-priority and cache.
+
+See: <https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types/prefetch>
+
+-}
+prefetchLink : String -> Maybe FileType -> Maybe CrossOrigin -> Tag
+prefetchLink =
+    resourceHintWithOptionalAttributes Prefetch
+
+
+resourceHintWithOptionalAttributes : ResourceHint -> String -> Maybe FileType -> Maybe CrossOrigin -> Tag
+resourceHintWithOptionalAttributes hint href fileType crossOrigin =
+    resourceHintLink hint
+        href
+        (Maybe.map (resourceFileTypeToString >> raw) fileType)
+        (Maybe.map (crossOriginToString >> raw) crossOrigin)
+
+
+crossOriginToString : CrossOrigin -> String
+crossOriginToString crossOrigin =
+    case crossOrigin of
+        Anonymous ->
+            "anonymous"
+
+        UseCredentials ->
+            "use-credentials"
+
+
+resourceFileTypeToString : FileType -> String
+resourceFileTypeToString fileType =
+    case fileType of
+        Audio ->
+            "audio"
+
+        Document ->
+            "document"
+
+        Embed ->
+            "embed"
+
+        Fetch ->
+            "fetch"
+
+        Font ->
+            "font"
+
+        Image ->
+            "image"
+
+        Object ->
+            "object"
+
+        Script ->
+            "script"
+
+        Style ->
+            "style"
+
+        Track ->
+            "track"
+
+        Worker ->
+            "worker"
+
+        Video ->
+            "video"


### PR DESCRIPTION
Hi, this PR adds a mechanism for adding resource hint link tags to the head. It covers the use case in #269 while being more restrictive than the proposed solution in #268.

Question: should a file type always be required for tags that support it? It's not required per the spec, but it's a best practice and mean one less `Maybe` in the API.

Let me know what you think, thanks!