### PR TITLE
CI test cache fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - master
-      - debug
   pull_request:
     branches:
       - master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - debug
   pull_request:
     branches:
       - master
@@ -39,8 +40,6 @@ jobs:
       # Install npm packages, unless we restored them from cache.
       # Since `npm ci` removes the node_modules folder before running it’s
       # important to skip this step if cache was restored.
-      - name: Lamdera Reset for tests
-        run: rm -rf elm-stuff $HOME/.elm
       - name: npm ci
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         env:
@@ -69,8 +68,7 @@ jobs:
       - name: Build elm docs
         id: docs
         run: npx --no-install elm make --docs docs.json
-      - name: Lamdera Reset for cypress
-        run: yes | lamdera reset
+
       - name: Setup for cypress
         run: (cd examples/end-to-end && npm install && npx elm-tooling install && rm -rf elm-stuff && npx elm-pages codegen && lamdera make app/Route/Index.elm)
       - name: Cypress tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
         run: npx --no-install elm-format --validate src/ generator/src
       - name: Build elm docs
         id: docs
-        run: npx --no-install elm make --docs docs.json
+        run: lamdera make --docs docs.json
 
       - name: Setup for cypress
         run: (cd examples/end-to-end && npm install && npx elm-tooling install && rm -rf elm-stuff && npx elm-pages codegen && lamdera make app/Route/Index.elm)

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "index.js",
   "scripts": {
     "start": "cd examples/end-to-end && npm i && npx elm-pages dev",
-    "test": "set -x; (cd examples/routing && npm i && npm run build && elm-test-rs --compiler=lamdera) && npm run test:snapshot && npx elmi-to-json --version && rm -rf elm-stuff && elm-verify-examples --run-tests --elm-test-args '--compiler=lamdera' && elm-test-rs --compiler=lamdera && (cd generator && mocha)",
+    "test": "./test.sh",
     "test:snapshot": "(cd examples/escaping && npm install && npm test) && (cd examples/base-path && npm install && npm test)",
     "cypress": "npm start & cypress run",
     "review": "elm-review"

--- a/src/Form.elm
+++ b/src/Form.elm
@@ -10,10 +10,8 @@ module Form exposing
     , parse, runServerSide, runOneOfServerSide
     , dynamic
     , AppContext
-    ,  toServerForm
-       -- subGroup
-      , withOnSubmit
-
+    , toServerForm, withOnSubmit
+    -- subGroup
     )
 
 {-| One of the core features of elm-pages is helping you manage form data end-to-end, including
@@ -252,6 +250,11 @@ Totally customizable. Uses [`Form.FieldView`](Form-FieldView) to render all of t
 @docs dynamic
 
 @docs AppContext
+
+
+## Submission
+
+@docs toServerForm, withOnSubmit
 
 -}
 
@@ -645,6 +648,7 @@ hiddenField name (Field fieldParser _) (Form definitions parseFn toInitialValues
         )
 
 
+{-| -}
 toServerForm :
     Form
         error

--- a/src/Form/Validation.elm
+++ b/src/Form/Validation.elm
@@ -1,10 +1,9 @@
 module Form.Validation exposing
     ( Combined, Field, Validation
-    , andMap, andThen, fail, fromMaybe, fromResult, map, map2, parseWithError, succeed, withError, withErrorIf, withFallback
+    , andMap, andThen, fail, fromMaybe, fromResult, map, map2, parseWithError, succeed, succeed2, withError, withErrorIf, withFallback
     , value, fieldName, fieldStatus
     , map3, map4, map5, map6, map7, map8, map9
     , global
-    , succeed2
     )
 
 {-|
@@ -14,7 +13,7 @@ module Form.Validation exposing
 
 @docs Combined, Field, Validation
 
-@docs andMap, andThen, fail, fromMaybe, fromResult, map, map2, parseWithError, succeed, withError, withErrorIf, withFallback
+@docs andMap, andThen, fail, fromMaybe, fromResult, map, map2, parseWithError, succeed, succeed2, withError, withErrorIf, withFallback
 
 
 ## Field Metadata

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,9 @@
+set -ex;
+root=`pwd`
+yes | lamdera reset || true
+elm-test-rs --compiler=lamdera
+cd examples/routing && npm i && npm run build && elm-test-rs --compiler=lamdera && cd $root
+npm run test:snapshot
+npx elmi-to-json --version
+elm-verify-examples --run-tests --elm-test-args '--compiler=lamdera'
+cd generator && mocha && cd $root


### PR DESCRIPTION
So I wasn't able to figure out what exactly was causing the problem, but it seems the ordering meant that somewhere likely a component in the test setup overall was compiling with vanilla Elm first, causing a package cache issue.

I think ultimately in Lamdera we'll have to figure out a clever way to detect/purge invalid caches on the fly, but for now at least this gets things green up to the cypress stage, where it seems to fail for unrelated reasons due to cypress upgrades that are beyond me 😄 

