### PR TITLE
Adding og:image:type to Head.Seo.tagsForImage

### DIFF
--- a/src/Head/Seo.elm
+++ b/src/Head/Seo.elm
@@ -422,6 +422,7 @@ tagsForImage image =
     , ( "og:image:alt", image.alt |> Head.raw |> Just )
     , ( "og:image:width", image.dimensions |> Maybe.map .width |> Maybe.map String.fromInt |> Maybe.map Head.raw )
     , ( "og:image:height", image.dimensions |> Maybe.map .height |> Maybe.map String.fromInt |> Maybe.map Head.raw )
+    , ( "og:image:type", image.mimeType |> Maybe.map Head.raw )
     ]
 
 


### PR DESCRIPTION
Something small I found.  With `image.mimeType` defined in _Index.head_ for example. We can use this value when defined as `Just "image/png"`. as defined by The Open Graph protocol.  Regards.