### PR TITLE
Clean Console on Init

### DIFF
--- a/generator/template/public/index.js
+++ b/generator/template/public/index.js
@@ -3,8 +3,7 @@
 /** @type ElmPagesInit */
 export default {
   load: async function (elmLoaded) {
-    const app = await elmLoaded;
-    console.log("App loaded", app);
+    await elmLoaded;
   },
   flags: function () {
     return "You can decode this in Shared.elm using Json.Decode.string!";


### PR DESCRIPTION
For those that prefer a clean browser console on init. I figure this should be upstreamed this if the preference is widely held.