### PR TITLE
improve docs by adding scroll-margin-top on h2

### DIFF
--- a/examples/docs/src/TailwindMarkdownRenderer.elm
+++ b/examples/docs/src/TailwindMarkdownRenderer.elm
@@ -237,6 +237,7 @@ heading { level, rawText, children } =
                     , Tw.mt_10
                     , Tw.pb_1
                     , Tw.border_b
+                    , Css.property "scroll-margin-top" "80px"
                     ]
                 ]
                 [ Html.a


### PR DESCRIPTION
Currently each time we click a hash tag link, the h2 header is hidden under the main menu bar, that is not fancy. By following the next post, I have added `scroll-margin-top` to h2 element, this way he header text is always shown below the menu bar !

https://css-tricks.com/hash-tag-links-padding/