### PR TITLE
show the submenus only when its parent page is active

### DIFF
--- a/examples/docs/src/TableOfContents.elm
+++ b/examples/docs/src/TableOfContents.elm
@@ -275,6 +275,10 @@ level1Entry current (Entry data children) =
         , ul
             [ css
                 [ Tw.space_y_3
+                , if isCurrent then
+                    Tw.block
+                  else
+                    Tw.hidden
                 ]
             ]
             (children


### PR DESCRIPTION
Here is another small improvement to the docs. From the docs home page https://elm-pages.com/docs, the first time you click on a submenu, it does not jump to the expected location because the url is different. I think this is a limitation of browsers and there is no easy fix for SPAs. This patch will show the submenus only when the parent page is active so we do not need to worry about such navigation.