### PR TITLE
Fix build-time route example (routes->pages)

### DIFF
--- a/examples/docs/content/docs/05-file-based-routing.md
+++ b/examples/docs/content/docs/05-file-based-routing.md
@@ -52,8 +52,8 @@ route =
             { view = view }
 
 
-routes : BackendTask.BackendTask (List RouteParams)
-routes =
+pages : BackendTask.BackendTask (List RouteParams)
+pages =
     BackendTask.succeed [ { slug = "introducing-elm-pages" } ]
 ```
 


### PR DESCRIPTION
The reference in `RouteBuilder.preRender` was updated, but the value it referenced still had the old `routes` name.

In https://elm-pages.com/docs/file-based-routing:
![image](https://github.com/dillonkearns/elm-pages/assets/289969/aa13c978-c3ac-4d45-bcee-0b4088477f2d)
