### PR TITLE
Use username variable in elm-pages-scripts example

### DIFF
--- a/examples/docs/content/docs/11-elm-pages-scripts.md
+++ b/examples/docs/content/docs/11-elm-pages-scripts.md
@@ -83,7 +83,7 @@ run =
     Script.withCliOptions program
         (\{ username, repo } ->
             BackendTask.Http.getJson
-                ("https://api.github.com/repos/dillonkearns/" ++ repo)
+                ("https://api.github.com/repos/" ++ username ++ "/" ++ repo)
                 (Decode.field "stargazers_count" Decode.int)
                 |> BackendTask.andThen
                     (\stars ->


### PR DESCRIPTION
There is a variable `username` but it is actually never used in the example and `dillonkearns` is hardcoded instead. I think this is not correct and therefor I suggest to actually use the variable