### PR TITLE
Makes BackendTask.combine stack safe

### DIFF
--- a/src/BackendTask.elm
+++ b/src/BackendTask.elm
@@ -206,6 +206,8 @@ sequence items =
 
 sequenceHelp : List (BackendTask error value) -> BackendTask error (List value) -> BackendTask error (List value)
 sequenceHelp items combined =
+    -- elm-review: known-unoptimized-recursion
+    -- counterintuitively this is stack safe, whereas putting sequenceHelp in tail call optimized position blows the stack
     case items of
         item :: rest ->
             combined |> andThen (\xs -> sequenceHelp rest (map (\x -> x :: xs) item))

--- a/src/BackendTask.elm
+++ b/src/BackendTask.elm
@@ -2,7 +2,7 @@ module BackendTask exposing
     ( BackendTask
     , map, succeed, fail
     , fromResult
-    , andThen, resolve, combine, sequence
+    , andThen, resolve, combine
     , andMap
     , map2, map3, map4, map5, map6, map7, map8, map9
     , allowFatal, mapError, onError, toResult
@@ -73,7 +73,7 @@ Any place in your `elm-pages` app where the framework lets you pass in a value o
 
 ## Chaining Requests
 
-@docs andThen, resolve, combine, sequence
+@docs andThen, resolve, combine
 
 @docs andMap
 
@@ -195,25 +195,6 @@ There's probably a way of doing this without the Lists but it's a neat trick to 
 combineHelp : List (BackendTask error value) -> BackendTask error (List value)
 combineHelp items =
     List.foldl (map2 (::)) (succeed []) items |> map List.reverse
-
-
-{-| Like combine, but runs each task one after the other
--}
-sequence : List (BackendTask error value) -> BackendTask error (List value)
-sequence items =
-    sequenceHelp items (succeed [])
-
-
-sequenceHelp : List (BackendTask error value) -> BackendTask error (List value) -> BackendTask error (List value)
-sequenceHelp items combined =
-    -- elm-review: known-unoptimized-recursion
-    -- counterintuitively this is stack safe, whereas putting sequenceHelp in tail call optimized position blows the stack
-    case items of
-        item :: rest ->
-            combined |> andThen (\xs -> sequenceHelp rest (map (\x -> x :: xs) item))
-
-        [] ->
-            combined
 
 
 {-| Like map, but it takes in two `Request`s.

--- a/src/BackendTask.elm
+++ b/src/BackendTask.elm
@@ -2,7 +2,7 @@ module BackendTask exposing
     ( BackendTask
     , map, succeed, fail
     , fromResult
-    , andThen, resolve, combine
+    , andThen, resolve, combine, sequence
     , andMap
     , map2, map3, map4, map5, map6, map7, map8, map9
     , allowFatal, mapError, onError, toResult
@@ -73,7 +73,7 @@ Any place in your `elm-pages` app where the framework lets you pass in a value o
 
 ## Chaining Requests
 
-@docs andThen, resolve, combine
+@docs andThen, resolve, combine, sequence
 
 @docs andMap
 
@@ -88,6 +88,7 @@ Any place in your `elm-pages` app where the framework lets you pass in a value o
 
 import FatalError exposing (FatalError)
 import Json.Encode
+import List.Chunks
 import Pages.StaticHttpRequest exposing (RawRequest(..))
 
 
@@ -173,7 +174,44 @@ resolve =
 -}
 combine : List (BackendTask error value) -> BackendTask error (List value)
 combine items =
+    items
+        |> List.Chunks.chunk 100
+        |> List.map combineHelp
+        |> List.Chunks.chunk 100
+        |> List.map combineHelp
+        |> List.Chunks.chunk 100
+        |> List.map combineHelp
+        |> combineHelp
+        |> map (List.concat >> List.concat >> List.concat)
+
+
+{-| `combineHelp` on its own will overflow the stack with larger lists of tasks
+
+dividing the tasks into smaller nested chunks and recombining makes `combine` stack safe
+
+There's probably a way of doing this without the Lists but it's a neat trick to safely combine lots of tasks!
+
+-}
+combineHelp : List (BackendTask error value) -> BackendTask error (List value)
+combineHelp items =
     List.foldl (map2 (::)) (succeed []) items |> map List.reverse
+
+
+{-| Like combine, but runs each task one after the other
+-}
+sequence : List (BackendTask error value) -> BackendTask error (List value)
+sequence items =
+    sequenceHelp items (succeed [])
+
+
+sequenceHelp : List (BackendTask error value) -> BackendTask error (List value) -> BackendTask error (List value)
+sequenceHelp items combined =
+    case items of
+        item :: rest ->
+            combined |> andThen (\xs -> sequenceHelp rest (map (\x -> x :: xs) item))
+
+        [] ->
+            combined
 
 
 {-| Like map, but it takes in two `Request`s.

--- a/src/List/Chunks.elm
+++ b/src/List/Chunks.elm
@@ -1,0 +1,50 @@
+module List.Chunks exposing (chunk)
+
+import Array exposing (Array)
+
+
+{-| Adapted from <https://package.elm-lang.org/packages/krisajenkins/elm-exts/latest/Exts-List>
+
+Split a list into chunks of length `n`.
+
+Be aware that the last sub-list may be smaller than `n`-items long.
+
+For example `chunk 3 [1..10] => [[1,2,3], [4,5,6], [7,8,9], [10]]`
+
+-}
+chunk : Int -> List a -> List (List a)
+chunk n xs =
+    if n < 1 then
+        List.singleton xs
+
+    else
+        evaluate (chunkInternal n xs Array.empty)
+
+
+chunkInternal : Int -> List a -> Array (List a) -> Trampoline (List (List a))
+chunkInternal n xs acc =
+    if List.isEmpty xs then
+        Done (Array.toList acc)
+
+    else
+        Jump
+            (\_ ->
+                chunkInternal n
+                    (List.drop n xs)
+                    (Array.push (List.take n xs) acc)
+            )
+
+
+type Trampoline a
+    = Done a
+    | Jump (() -> Trampoline a)
+
+
+evaluate : Trampoline a -> a
+evaluate trampoline =
+    case trampoline of
+        Done value ->
+            value
+
+        Jump f ->
+            evaluate (f ())

--- a/src/List/Chunks.elm
+++ b/src/List/Chunks.elm
@@ -23,6 +23,7 @@ chunk n xs =
 
 chunkInternal : Int -> List a -> Array (List a) -> Trampoline (List (List a))
 chunkInternal n xs acc =
+    -- elm-review: known-unoptimized-recursion
     if List.isEmpty xs then
         Done (Array.toList acc)
 


### PR DESCRIPTION
Hi 👋 I thought I'd suggest adding these from my explorations in making stack safe tasks!

Currently if you run `BackendTask.combine` with lots of tasks (> 10K on my machine) it blows up, but weirdly if you sub-batch smaller lists of tasks and re-concat them at the end it works with ~1M tasks. It's a bit of a weird trick and there's probably a way of doing it without the Lists but that's the best I've found so far (I have tried many, many things! 😂 ).