### PR TITLE
README: document use of submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - [elm-pages Elm API Docs](https://package.elm-lang.org/packages/dillonkearns/elm-pages/10.0.1/)
 - [Quick start repo](https://github.com/dillonkearns/elm-pages-starter) [(live site hosted here)](https://elm-pages-starter.netlify.com)
 - [Introducing `elm-pages` blog post](https://elm-pages.com/blog/introducing-elm-pages)
-- [`examples` folder](https://github.com/dillonkearns/elm-pages/blob/master/examples/) (includes https://elm-pages.com site source)
+- [`examples` folder](https://github.com/dillonkearns/elm-pages/blob/master/examples/) (includes https://elm-pages.com site source) Use `git clone --recurse-submodules https://github.com/dillonkearns/elm-pages.git` so that there aren't missing files when you try to build the examples.
 
 ## Compatibility Key
 


### PR DESCRIPTION
It's an easy beginner mistake to forget to check out the submodules and then the examples don't work.  See #395