### PR TITLE
Update Adapter API documentation

### DIFF
--- a/examples/docs/content/docs/15-adapters.md
+++ b/examples/docs/content/docs/15-adapters.md
@@ -102,10 +102,11 @@ async function render(event, context) {
 
 /**
  * @param {import('aws-lambda').APIGatewayProxyEvent} req
- * @returns {{method: string; rawUrl: string; body: string?; headers: Record<string, string>; multiPartFormData: unknown }}
+ * @returns {{requestTime: number, method: string; rawUrl: string; body: string?; headers: Record<string, string>; multiPartFormData: unknown }}
  */
 function reqToJson(req) {
   return {
+    requestTime: Math.round(new Date().getTime()),
     method: req.httpMethod,
     headers: req.headers,
     rawUrl: req.rawUrl,


### PR DESCRIPTION
Without including the `requestTime` property the `Internal.Request.Request.requestDecoder` fails to decode the `Request`.