### PR TITLE
fix #414: use the statusCode and headers fields from the response.body instead of the response.

### DIFF
--- a/generator/src/build.js
+++ b/generator/src/build.js
@@ -232,9 +232,9 @@ export async function render(request) {
     // isBase64Encoded
     return {
         body: response.body.body,
-        statusCode: response.statusCode,
+        statusCode: response.body.statusCode,
         kind: response.kind,
-        headers: response.headers,
+        headers: response.body.headers,
         isBase64Encoded: response.body.isBase64Encoded,
     }
   } else {


### PR DESCRIPTION
This makes the production build behave the same to the dev version here:

https://github.com/dillonkearns/elm-pages/blob/57dccef4334e264659af53465de786028e9566d9/generator/src/dev-server.js#L550-L553

I would have liked to add some tests for this as well, but I could not find an existing place similar enough to add them to, and I didn't want to go ahead and just add end-to-end testing stuff that you might not want :)