### PR TITLE
Fix un-awaited Promise.all in runElmReviewCodeMod

### DIFF
--- a/generator/src/codegen.js
+++ b/generator/src/codegen.js
@@ -72,7 +72,7 @@ export async function generate(basePath) {
 }
 
 function writeFetcherModules(basePath, fetcherData) {
-  Promise.all(
+  return Promise.all(
     fetcherData.map(([name, fileContent]) => {
       let filePath = path.join(basePath, `/Fetcher/${name.join("/")}.elm`);
       ensureDirSync(path.dirname(filePath));


### PR DESCRIPTION
Noticed that this Promise.all() call that was meant to be awaited was not awaited. Not sure if this created problems in practice, but probably at least technically was a race condition.