### PR TITLE
Fix missing response headers for ApiRoutes

### DIFF
--- a/generator/src/build.js
+++ b/generator/src/build.js
@@ -234,7 +234,7 @@ export async function render(request) {
         body: response.body.body,
         statusCode: response.statusCode,
         kind: response.kind,
-        headers: response.headers,
+        headers: response.body.headers,
         isBase64Encoded: response.body.isBase64Encoded,
     }
   } else {

--- a/generator/src/compatibility-key.js
+++ b/generator/src/compatibility-key.js
@@ -1,3 +1,3 @@
 export const compatibilityKey = 21;
 
-export const packageVersion = "3.0.11";
+export const packageVersion = "3.0.12";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "elm-pages",
-  "version": "3.0.11",
+  "version": "3.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "elm-pages",
-      "version": "3.0.11",
+      "version": "3.0.12",
       "license": "BSD-3-Clause",
       "dependencies": {
         "busboy": "^1.6.0",


### PR DESCRIPTION
I put in some debug code where I made this change and discovered the headers are only present in the `body` object.

The statusCode is present in the `body` object as well, but it is also in the main object, so I left that intact.

