### PR TITLE
Fix config not loading on Windows

### DIFF
--- a/generator/src/config.js
+++ b/generator/src/config.js
@@ -1,8 +1,10 @@
 import * as path from "path";
+import { pathToFileURL } from "url";
 
 export async function resolveConfig() {
+  const configPath = path.join(process.cwd(), "elm-pages.config.mjs");
   const initialConfig = await await import(
-    path.join(process.cwd(), "elm-pages.config.mjs")
+    pathToFileURL(configPath)
   )
     .then(async (elmPagesConfig) => {
       return (


### PR DESCRIPTION
On my Windows machine, it was always printing this error message, even though there's a default config in place:
>No `elm-pages.config.mjs` file found. Using default config.

Looking more deeply into it, the following error was being thrown from the `import` call:
>Error [ERR_UNSUPPORTED_ESM_URL_SCHEME]: Only URLs with a scheme in: file, data, and node are supported by the default ESM loader. On Windows, absolute paths must be valid file:// URLs.

This PR, therefore, always converts the file path into a file URL before attempting to import it.