### PR TITLE
Move elm-codegen to be a test dependency

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -71,7 +71,6 @@
         "elm-community/list-extra": "8.6.0 <= v < 9.0.0",
         "jluckyiv/elm-utc-date-strings": "1.0.0 <= v < 2.0.0",
         "justinmimbs/date": "4.0.1 <= v < 5.0.0",
-        "mdgriffith/elm-codegen": "5.0.0 <= v < 6.0.0",
         "miniBill/elm-codec": "2.0.0 <= v < 3.0.0",
         "noahzgordon/elm-color-extra": "1.0.2 <= v < 2.0.0",
         "robinheghan/fnv1a": "1.0.0 <= v < 2.0.0",
@@ -82,6 +81,7 @@
     "test-dependencies": {
         "avh4/elm-program-test": "4.0.0 <= v < 5.0.0",
         "elm-explorations/test": "2.0.1 <= v < 3.0.0",
-        "the-sett/elm-pretty-printer": "3.0.0 <= v < 4.0.0"
+        "the-sett/elm-pretty-printer": "3.0.0 <= v < 4.0.0",
+        "mdgriffith/elm-codegen": "5.0.0 <= v < 6.0.0"
     }
 }


### PR DESCRIPTION
I realized that `elm-codegen` is not actually used by `elm-pages`-the-library, so it can be moved to be a test dependency