### PR TITLE
docs site: use BlogPost type to describe filePath and slug

### DIFF
--- a/examples/docs/src/Article.elm
+++ b/examples/docs/src/Article.elm
@@ -18,7 +18,7 @@ type alias BlogPost =
     }
 
 
-blogPostsGlob : BackendTask.BackendTask error (List { filePath : String, slug : String })
+blogPostsGlob : BackendTask.BackendTask error (List BlogPost)
 blogPostsGlob =
     Glob.succeed BlogPost
         |> Glob.captureFilePath


### PR DESCRIPTION
This PR uses the type alias to make it easier to read the type signature.