### PR TITLE
Fix broken Form link in the documentation

### DIFF
--- a/examples/docs/content/docs/01-what-is-elm-pages.md
+++ b/examples/docs/content/docs/01-what-is-elm-pages.md
@@ -56,7 +56,7 @@ Some of the core features include
 
 Many of the core features of `elm-pages` are designed to support these use cases.
 
-- [Forms](/docs/forms)
+- [Forms](/docs/use-the-platform#forms)
 - In-flight submissions
 - Server-side rendering
 - [Session API](https://package.elm-lang.org/packages/dillonkearns/elm-pages/latest/Server-Session)


### PR DESCRIPTION
### Problem
There is a broken link to the Form-section in the docs.

### Solution
Fix the link. Note that I’m not completely sure that `/docs/use-the-platform#forms` is where you want to send people but it was the best place I could find. Feel free to update to something better.
