### PR TITLE
Avoid unnecessary rerenders at init

### DIFF
--- a/examples/escaping/dist/escaping/index.html
+++ b/examples/escaping/dist/escaping/index.html
@@ -13,8 +13,4 @@
     <script type="module" crossorigin src="/assets/index.HASH.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index.HASH.css">
   </head>
-  <body>
-    <div data-url="" display="none"></div>
-    <div><span class="elm-css-style-wrapper" style="display: none;"><style></style></span><label for="note"></label><div><span class="elm-css-style-wrapper" style="display: none;"><style>div > p{font-size:14px;color:rgb(255,0,0);}</style></span><div><p>Hello! 2 &gt; 1</p></div></div>&lt;script&gt;&lt;/script&gt; is unsafe in JSON unless it is escaped properly.&lt;script&gt;&lt;/script&gt; is unsafe in JSON unless it is escaped properly.<ul><li><span class="elm-css-style-wrapper" style="display: none;"><style></style></span>This is number 0</li></ul><ul><div><li><span class="elm-css-style-wrapper" style="display: none;"><style></style></span>This is nested number 0</li></div></ul></div>
-  </body>
-</html>
+  <body><div data-url="" style="display: none;"></div><div id="elm-pages-announcer" aria-live="assertive" aria-atomic="true" style="position: absolute; top: 0; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); whiteSpace: nowrap; border: 0;"></div><div><span class="elm-css-style-wrapper" style="display: none;"><style></style></span><label for="note"></label><div><span class="elm-css-style-wrapper" style="display: none;"><style>div > p{font-size:14px;color:rgb(255,0,0);}</style></span><div><p>Hello! 2 &gt; 1</p></div></div>&lt;script&gt;&lt;/script&gt; is unsafe in JSON unless it is escaped properly.&lt;script&gt;&lt;/script&gt; is unsafe in JSON unless it is escaped properly.<ul><li><span class="elm-css-style-wrapper" style="display: none;"><style></style></span>This is number 0</li></ul><ul><div><li><span class="elm-css-style-wrapper" style="display: none;"><style></style></span>This is nested number 0</li></div></ul></div></body></html>

--- a/generator/src/pre-render-html.js
+++ b/generator/src/pre-render-html.js
@@ -48,11 +48,11 @@ export function templateHtml(devMode, userHeadTagsTemplate) {
     ${indent(userHeadTagsTemplate({ cliVersion: packageVersion }))}
     <!-- PLACEHOLDER_HEAD_AND_DATA -->
   </head>
-  <body>
-    <div data-url="" display="none"></div>
-    <!-- PLACEHOLDER_HTML -->
-  </body>
-</html>`;
+  <body><div data-url="" style="display: none;"></div><div id="elm-pages-announcer" aria-live="assertive" aria-atomic="true" style="position: absolute; top: 0; width: 1px; height: 1px; padding: 0; overflow: hidden; clip: rect(0, 0, 0, 0); whiteSpace: nowrap; border: 0;"></div><!-- PLACEHOLDER_HTML --></body></html>`;
+  // NOTE: The above line needs to:
+  // - Be in sync with `view` in Platform.elm (render the same elements).
+  // - Not include any extra whitespace. Even whitespace between </body> and </html> is parsed by browsers as a text node _inside_ <body>.
+  // This is to avoid unnecessary rerenders on init (when the first `view` call is diffed with the virtualized form of the above HTML).
 }
 
 /**

--- a/src/AriaLiveAnnouncer.elm
+++ b/src/AriaLiveAnnouncer.elm
@@ -17,6 +17,7 @@ view title =
 
 mainView : String -> Html msg
 mainView title =
+    -- NOTE: If you make changes here, also update pre-render-html.js!
     Html.div
         [ Attr.id "elm-pages-announcer"
         , Attr.attribute "aria-live" "assertive"

--- a/src/Pages/Internal/Platform.elm
+++ b/src/Pages/Internal/Platform.elm
@@ -123,6 +123,7 @@ view config model =
     in
     { title = title
     , body =
+        -- NOTE: If you make changes here, also update pre-render-html.js!
         [ onViewChangeElement model.url
         , AriaLiveAnnouncer.view model.ariaNavigationAnnouncement
         ]
@@ -136,9 +137,10 @@ onViewChangeElement currentUrl =
     -- it is used from the JS-side to reliably
     -- check when Elm has changed pages
     -- (and completed rendering the view)
+    -- NOTE: If you make changes here, also update pre-render-html.js!
     Html.div
         [ Attr.attribute "data-url" (Url.toString currentUrl)
-        , Attr.attribute "display" "none"
+        , Attr.style "display" "none"
         ]
         []
 

--- a/src/Pages/Internal/Platform/Cli.elm
+++ b/src/Pages/Internal/Platform/Cli.elm
@@ -1025,7 +1025,8 @@ render404Page config sharedData isDevServer path notFoundReason =
 
 bodyToString : List (Html msg) -> String
 bodyToString body =
-    body |> List.map (HtmlPrinter.htmlToString Nothing) |> String.join "\n"
+    -- NOTE: Don’t join the strings with a newline here – see pre-render-html.js.
+    body |> List.map (HtmlPrinter.htmlToString Nothing) |> String.concat
 
 
 urlToRoute : ProgramConfig userMsg userModel route pageData actionData sharedData effect mappedMsg errorPage -> Url -> route


### PR DESCRIPTION
When an Elm app boots, it “virtualizes” existing DOM and diffs against that on the first render. If the existing DOM was similar to the return value of the first `view`, not much of the DOM needs to be updated.

https://github.com/elm/browser/blob/1.0.2/src/Elm/Kernel/Browser.js#L78-L85

Most Elm apps render into empty or near-empty nodes, so that is rarely relevant. But elm-pages server-side renders views, so it can take advantage of this feature!

However, there is currently a mismatch between the server rendered HTML and what the Elm view produces. The diff at init looks like this:

1. ✅  `<body>` vs `<body>`
2. ✅  `<div data-url>` vs `<div data-url>`
3. ❌ `<main>` vs `<div id="elm-pages-announcer">`
4. ❌ nothing vs `<main>`

Since `<div id="elm-pages-announcer">` is missing in the server-side rendered HTML, it throws off the diffing forcing Elm to basically rerender the entire page.

Then, to make things more complicated, whitespace matters too. When hand-writing HTML, we often put newlines and indentation among elements to make things more readable. However, that results in text nodes with only whitespace! Usually they don’t matter at all, but they do matter when virtualizing DOM. Elm can’t know which text nodes are important and which ones aren’t. `<b>one</b> <b>two</b>` has a whitespace-only text node which is important – without it the text renders as “onetwo” instead of “one two”. So just adding `<div id="elm-pages-announcer">` to the server-side rendered HTML isn’t enough – there are some whitespace text nodes that throw things off as well.

This PR:

- Adds `<div id="elm-pages-announcer">` to the server-side rendered HTML.
- Removes whitespace text nodes in `<body>`.
- Adds comments about this.

I found this when working on my fork of elm/virtual-dom. Which brings me to … this PR only avoids unnecessary rerenders in _theory._ Because as soon as you wrap something in `Html.map` or `Html.Lazy.lazy`, everything inside them is going to be rendered anyway. elm-pages does `List.map (Html.map UserMsg) body` to the user’s view, so basically the whole page is wrapped in `Html.map`. The reason this causes a rerender, is because elm/virtual-dom’s virtualize function cannot know where `map` nodes should be, and the diffing algorithm bails when a `map` node is diffed with a regular node. My fork of elm/virtual-dom handles this, though, so when that is finished, this PR will have value for those who choose to use my fork!

My fork isn’t done yet, though, but I thought I’d make this PR while I still remember all the details.