### PR TITLE
Only load elm.{hash}.js once

### DIFF
--- a/examples/escaping/dist/escaping/index.html
+++ b/examples/escaping/dist/escaping/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title></title>
-    <link rel="modulepreload" crossorigin href="/elm.HASH.js"><link rel="modulepreload" crossorigin href="/assets/index.HASH.js">
+    <link rel="preload" as="script" href="/elm.HASH.js"><link rel="modulepreload" crossorigin href="/assets/index.HASH.js">
     <script defer src="/elm.HASH.js" type="text/javascript"></script>
         
     

--- a/generator/src/build.js
+++ b/generator/src/build.js
@@ -741,7 +741,9 @@ async function runAdapter(adaptFn, processedIndexTemplate) {
  * @param {string} file
  */
 function defaultPreloadForFile(file) {
-  if (file.endsWith(".js")) {
+  if (/\/elm\.[a-f0-9]+\.js$/.test(file)) {
+    return `<link rel="preload" as="script" href="${file}">`;
+  } else if (file.endsWith(".js")) {
     return `<link rel="modulepreload" crossorigin href="${file}">`;
   } else if (file.endsWith(".css")) {
     return `<link rel="preload" href="${file}" as="style">`;


### PR DESCRIPTION
Only load elm.{hash}.js once by preloading without `crossorigin`, and convert from `modulepreload` to `preload`.

Fixes #500.

Before:
<img width="2226" height="1306" alt="image" src="https://github.com/user-attachments/assets/56b23061-3e1d-4f15-9c95-893493502c39" />

After:
<img width="2232" height="1356" alt="image" src="https://github.com/user-attachments/assets/68ecdc8a-4637-4705-9ec3-18dcfcf224da" />
