### PR TITLE
Stub out `pages` function in pre-rendered Routes to optimize client bundle

### DIFF
--- a/generator/dead-code-review/src/Pages/Review/DeadCodeEliminateData.elm
+++ b/generator/dead-code-review/src/Pages/Review/DeadCodeEliminateData.elm
@@ -145,7 +145,7 @@ declarationVisitor node context =
                                             (\recordSetter ->
                                                 case Node.value recordSetter of
                                                     ( keyNode, valueNode ) ->
-                                                        if Node.value keyNode == "data" || Node.value keyNode == "action" then
+                                                        if Node.value keyNode == "data" || Node.value keyNode == "action" || Node.value keyNode == "pages" then
                                                             if isAlreadyApplied context.lookupTable (Node.value valueNode) then
                                                                 Nothing
 
@@ -203,7 +203,7 @@ expressionVisitor node context =
                                     (\recordSetter ->
                                         case Node.value recordSetter of
                                             ( keyNode, valueNode ) ->
-                                                if Node.value keyNode == "data" || Node.value keyNode == "action" then
+                                                if Node.value keyNode == "data" || Node.value keyNode == "action" || Node.value keyNode == "pages" then
                                                     if isAlreadyApplied context.lookupTable (Node.value valueNode) then
                                                         Nothing
 
@@ -234,16 +234,28 @@ expressionVisitor node context =
                                             ++ " = "
                                             ++ (case pageBuilderName of
                                                     "preRender" ->
-                                                        "\\_ -> "
-                                                            ++ referenceFunction context.importContext ( [ "BackendTask" ], "fail" )
-                                                            ++ " "
-                                                            ++ exceptionFromString
+                                                        if key == "pages" then
+                                                            referenceFunction context.importContext ( [ "BackendTask" ], "fail" )
+                                                                ++ " "
+                                                                ++ exceptionFromString
+
+                                                        else
+                                                            "\\_ -> "
+                                                                ++ referenceFunction context.importContext ( [ "BackendTask" ], "fail" )
+                                                                ++ " "
+                                                                ++ exceptionFromString
 
                                                     "preRenderWithFallback" ->
-                                                        "\\_ -> "
-                                                            ++ referenceFunction context.importContext ( [ "BackendTask" ], "fail" )
-                                                            ++ " "
-                                                            ++ exceptionFromString
+                                                        if key == "pages" then
+                                                            referenceFunction context.importContext ( [ "BackendTask" ], "fail" )
+                                                                ++ " "
+                                                                ++ exceptionFromString
+
+                                                        else
+                                                            "\\_ -> "
+                                                                ++ referenceFunction context.importContext ( [ "BackendTask" ], "fail" )
+                                                                ++ " "
+                                                                ++ exceptionFromString
 
                                                     "serverRender" ->
                                                         "\\_ _ -> "


### PR DESCRIPTION
Similar to how the `data` and `action` functions are currently "stubbed out" so the Elm compiler can dead-code eliminate them from the client-side bundle.