### PR TITLE
`capture` can return undefined

### DIFF
--- a/generator/src/render.js
+++ b/generator/src/render.js
@@ -1223,7 +1223,7 @@ async function runGlobNew(req, patternsToWatch) {
         }
         return {
           fullPath: fullPath.path,
-          captures: mm.capture(pattern, fullPath.path),
+          captures: mm.capture(pattern, fullPath.path) || [],
           fileStats: {
             size: stats.size,
             atime: Math.round(stats.atime.getTime()),


### PR DESCRIPTION
This fixes an infinite loop that happens if there are no matches to be had, `capture` returns `undefined` and thus the decoder fails