### PR TITLE
Inline call to `getContext`

### DIFF
--- a/generator/src/render.js
+++ b/generator/src/render.js
@@ -568,7 +568,7 @@ function getContext(requestToPerform) {
 }
 
 async function readFileJobNew(req, patternsToWatch) {
-  const { cwd } = getContext(req);
+  const cwd = path.resolve(...req.dir);
   // TODO use cwd
   const filePath = path.resolve(cwd, req.body.args[1]);
   try {
@@ -1295,7 +1295,7 @@ export async function readKey() {
 }
 
 async function runWriteFileJob(req) {
-  const { cwd } = getContext(req);
+  const cwd = path.resolve(...req.dir);
   const data = req.body.args[0];
   const filePath = path.resolve(cwd, data.path);
   try {


### PR DESCRIPTION
This avoid calling `process.env` and having to merge dictionaries. I measured some modest but consistent performance improvement with this patch.