### PR TITLE
`messages` could contain any kind of data

### DIFF
--- a/generator/src/dev-server.js
+++ b/generator/src/dev-server.js
@@ -40,7 +40,10 @@ export async function start(options) {
     if (
       messages &&
       messages[0] &&
-      !messages[0].startsWith("Failed to load url")
+      !(
+        typeof messages[0] === "string" &&
+        messages[0].startsWith("Failed to load url")
+      )
     ) {
       console.info(...messages);
     }


### PR DESCRIPTION
If you try to `elm-pages dev` in a folder which is not correctly set up then `console.error` gets called with an object which is not a string