### PR TITLE
HTML sanitization to mirror virtual-dom

### DIFF
--- a/examples/escaping/app/Route/Escaping.elm
+++ b/examples/escaping/app/Route/Escaping.elm
@@ -158,6 +158,24 @@ view static sharedModel =
             , Attr.attribute "after" "2"
             ]
             []
+        , snapshotComment "on* and formAction attributes are rewritten"
+        , Html.div
+            [ Attr.attribute "onclick" "alert(0)"
+            , Attr.attribute "formAction" "submit"
+            ]
+            []
+        , snapshotComment "innerHTML, outerHTML, and formAction properties are rewritten"
+        , Html.div
+            [ Attr.property "innerHTML" (Json.Encode.string "<script>alert(0)</script>")
+            , Attr.property "outerHTML" (Json.Encode.string "<script>alert(1)</script>")
+            , Attr.property "formAction" (Json.Encode.string "/submit")
+            ]
+            []
+        , snapshotComment "javascript: and data:text/html URLs are stripped"
+        , Html.div []
+            [ Html.a [ Attr.href "javascript:alert(0)" ] [ Html.text "Bad link" ]
+            , Html.img [ Attr.src "data:text/html,<script>alert(0)</script>" ] []
+            ]
         , snapshotComment "attribute values are escaped"
         , Html.div [ Attr.title "\"'><script>true && alert(0)</script>" ] []
         , snapshotComment "class attribute values are escaped (it is special cased)"
@@ -174,5 +192,7 @@ view static sharedModel =
         , Html.node "script" [] [ Html.text "0 < 1 && alert(0)" ]
         , snapshotComment "style tags are allowed, and contain raw text"
         , Html.node "style" [] [ Html.text "body > * { html & { display: none; } }" ]
+        , snapshotComment "closing style tag in style content cannot break out"
+        , Html.node "style" [] [ Html.text "</style><img src=x onerror=alert(1)>" ]
         ]
     }

--- a/examples/escaping/dist/escaping/index.html
+++ b/examples/escaping/dist/escaping/index.html
@@ -36,6 +36,15 @@
 # invalid attributes are skipped, both string and boolean
 <div after="2" before="1"></div>
 
+# on* and formAction attributes are rewritten
+<div data-formAction="submit" data-onclick="alert(0)"></div>
+
+# innerHTML, outerHTML, and formAction properties are rewritten
+<div data-formAction="/submit" data-innerHTML="&lt;script&gt;alert(0)&lt;/script&gt;" data-outerHTML="&lt;script&gt;alert(1)&lt;/script&gt;"></div>
+
+# javascript: and data:text/html URLs are stripped
+<div><a href="">Bad link</a><img src=""></div>
+
 # attribute values are escaped
 <div title="&quot;&#039;&gt;&lt;script&gt;true &amp;&amp; alert(0)&lt;/script&gt;"></div>
 
@@ -58,4 +67,7 @@
 <p>0 &lt; 1 &amp;&amp; alert(0)</p>
 
 # style tags are allowed, and contain raw text
-<style>body > * { html & { display: none; } }</style></div></body></html>
+<style>body > * { html & { display: none; } }</style>
+
+# closing style tag in style content cannot break out
+<style><\/style><img src=x onerror=alert(1)></style></div></body></html>

--- a/src/Test/Html/Internal/ElmHtml/InternalTypes.elm
+++ b/src/Test/Html/Internal/ElmHtml/InternalTypes.elm
@@ -102,8 +102,8 @@ type alias EventHandler =
 
   - styles are a mapping of rules
   - events may be a json object containing event handlers
-  - attributes are pulled out into stringAttributes and boolAttributes - things with string values go into
-    stringAttributes, things with bool values go into boolAttributes
+  - attributes are pulled out into stringAttributes
+  - properties are pulled out into stringProperties and boolProperties
 
 -}
 type alias Facts msg =
@@ -111,7 +111,8 @@ type alias Facts msg =
     , events : Dict String (VirtualDom.Handler msg)
     , attributeNamespace : Maybe Json.Decode.Value
     , stringAttributes : Dict String String
-    , boolAttributes : Dict String Bool
+    , stringProperties : Dict String String
+    , boolProperties : Dict String Bool
     }
 
 
@@ -321,19 +322,6 @@ decodeStyles =
         ]
 
 
-{-| grab things from attributes via a decoder, then anything that isn't filtered on
-the object
--}
-decodeOthers : Json.Decode.Decoder a -> Json.Decode.Decoder (Dict String a)
-decodeOthers otherDecoder =
-    decodeAttributes otherDecoder
-        |> Json.Decode.andThen
-            (\attributes ->
-                decodeDictFilterMap otherDecoder
-                    |> Json.Decode.map (filterKnownKeys >> Dict.union attributes)
-            )
-
-
 {-| For a given decoder, keep the values from a dict that pass the decoder
 -}
 decodeDictFilterMap : Json.Decode.Decoder a -> Json.Decode.Decoder (Dict String a)
@@ -362,6 +350,12 @@ decodeAttributes decoder =
         ]
 
 
+decodeProperties : Json.Decode.Decoder a -> Json.Decode.Decoder (Dict String a)
+decodeProperties decoder =
+    decodeDictFilterMap decoder
+        |> Json.Decode.map filterKnownKeys
+
+
 decodeEvents : (EventHandler -> VirtualDom.Handler msg) -> Json.Decode.Decoder (Dict String (VirtualDom.Handler msg))
 decodeEvents taggedEventDecoder =
     Json.Decode.oneOf
@@ -374,12 +368,13 @@ decodeEvents taggedEventDecoder =
 -}
 decodeFacts : HtmlContext msg -> Json.Decode.Decoder (Facts msg)
 decodeFacts (HtmlContext taggers eventDecoder) =
-    Json.Decode.map5 Facts
+    Json.Decode.map6 Facts
         decodeStyles
         (decodeEvents (eventDecoder taggers))
         (Json.Decode.maybe (Json.Decode.field attributeNamespaceKey Json.Decode.value))
-        (decodeOthers Json.Decode.string)
-        (decodeOthers Json.Decode.bool)
+        (decodeAttributes Json.Decode.string)
+        (decodeProperties Json.Decode.string)
+        (decodeProperties Json.Decode.bool)
 
 
 {-| Just empty facts
@@ -390,7 +385,8 @@ emptyFacts =
     , events = Dict.empty
     , attributeNamespace = Nothing
     , stringAttributes = Dict.empty
-    , boolAttributes = Dict.empty
+    , stringProperties = Dict.empty
+    , boolProperties = Dict.empty
     }
 
 

--- a/src/Test/Html/Internal/ElmHtml/ToString.elm
+++ b/src/Test/Html/Internal/ElmHtml/ToString.elm
@@ -12,6 +12,7 @@ module Test.Html.Internal.ElmHtml.ToString exposing
 -}
 
 import Dict
+import Regex exposing (Regex)
 import String
 import Test.Html.Internal.ElmHtml.InternalTypes exposing (..)
 
@@ -80,6 +81,12 @@ nests them under this one
 nodeRecordToString : FormatOptions -> NodeRecord msg -> List String
 nodeRecordToString options { tag, children, facts } =
     let
+        safeTag =
+            noScript tag
+
+        elementKind =
+            toElementKind safeTag
+
         openTag : List (Maybe String) -> String
         openTag extras =
             let
@@ -96,13 +103,13 @@ nodeRecordToString options { tag, children, facts } =
                         more ->
                             " " ++ String.join " " more
             in
-            "<" ++ tag ++ filling ++ ">"
+            "<" ++ safeTag ++ filling ++ ">"
 
         closeTag =
-            "</" ++ tag ++ ">"
+            "</" ++ safeTag ++ ">"
 
         childrenStrings =
-            List.map (nodeToLines (toElementKind tag) options) children
+            List.map (nodeToLines elementKind options) children
                 |> List.concat
                 |> List.map ((++) (String.repeat options.indent " "))
 
@@ -119,20 +126,32 @@ nodeRecordToString options { tag, children, facts } =
                         |> Just
 
         classes =
-            Dict.get "className" facts.stringAttributes
-                |> Maybe.map (\name -> "class=\"" ++ escapeHtml name ++ "\"")
+            Dict.get "className" facts.stringProperties
+                |> Maybe.map (noJavaScriptOrHtmlUri >> escapeHtml >> (\name -> "class=\"" ++ name ++ "\""))
 
         stringAttributes =
-            Dict.filter (\k v -> k /= "className") facts.stringAttributes
+            facts.stringAttributes
                 |> Dict.toList
+                |> List.map (\( k, v ) -> ( noOnOrFormAction k, noJavaScriptOrHtmlUri v ))
                 |> List.filter (\( k, _ ) -> not (isUnsafeName k))
-                |> List.map (Tuple.mapFirst propertyToAttributeName)
                 |> List.map (\( k, v ) -> k ++ "=\"" ++ escapeHtml v ++ "\"")
                 |> String.join " "
                 |> Just
 
-        boolAttributes =
-            Dict.toList facts.boolAttributes
+        stringProperties =
+            Dict.filter (\k _ -> k /= "className") facts.stringProperties
+                |> Dict.toList
+                |> List.map (\( k, v ) -> ( noInnerHtmlOrFormAction k, noJavaScriptOrHtmlUri v ))
+                |> List.map (\( k, v ) -> ( propertyToAttributeName k, v ))
+                |> List.filter (\( k, _ ) -> not (isUnsafeName k))
+                |> List.map (\( k, v ) -> k ++ "=\"" ++ escapeHtml v ++ "\"")
+                |> String.join " "
+                |> Just
+
+        boolProperties =
+            Dict.toList facts.boolProperties
+                |> List.map (\( k, v ) -> ( noInnerHtmlOrFormAction k, v ))
+                |> List.map (\( k, v ) -> ( propertyToAttributeName k, v ))
                 |> List.filter (\( k, _ ) -> not (isUnsafeName k))
                 |> List.filterMap
                     (\( k, v ) ->
@@ -145,7 +164,7 @@ nodeRecordToString options { tag, children, facts } =
                 |> String.join " "
                 |> Just
     in
-    case toElementKind tag of
+    case elementKind of
         InvalidElements ->
             [ "<!-- invalid element -->" ]
 
@@ -153,10 +172,10 @@ nodeRecordToString options { tag, children, facts } =
            specified for void elements.
         -}
         VoidElements ->
-            [ openTag [ classes, styles, stringAttributes, boolAttributes ] ]
+            [ openTag [ classes, styles, stringAttributes, stringProperties, boolProperties ] ]
 
         _ ->
-            [ openTag [ classes, styles, stringAttributes, boolAttributes ] ]
+            [ openTag [ classes, styles, stringAttributes, stringProperties, boolProperties ] ]
                 ++ childrenStrings
                 ++ [ closeTag ]
 
@@ -182,6 +201,57 @@ propertyToAttributeName propertyName =
             propertyName
 
 
+noScript : String -> String
+noScript tag =
+    if String.toLower tag == "script" then
+        "p"
+
+    else
+        tag
+
+
+noOnOrFormAction : String -> String
+noOnOrFormAction key =
+    let
+        lowerKey =
+            String.toLower key
+    in
+    if String.startsWith "on" lowerKey || lowerKey == "formaction" then
+        "data-" ++ key
+
+    else
+        key
+
+
+noInnerHtmlOrFormAction : String -> String
+noInnerHtmlOrFormAction key =
+    if key == "innerHTML" || key == "outerHTML" || key == "formAction" then
+        "data-" ++ key
+
+    else
+        key
+
+
+noJavaScriptOrHtmlUri : String -> String
+noJavaScriptOrHtmlUri value =
+    if isJavaScriptOrHtmlUri value then
+        ""
+
+    else
+        value
+
+
+isJavaScriptOrHtmlUri : String -> Bool
+isJavaScriptOrHtmlUri value =
+    Regex.contains javaScriptOrHtmlUriRegex (String.toLower value)
+
+
+javaScriptOrHtmlUriRegex : Regex
+javaScriptOrHtmlUriRegex =
+    Regex.fromString "^\\s*(j\\s*a\\s*v\\s*a\\s*s\\s*c\\s*r\\s*i\\s*p\\s*t\\s*:|d\\s*a\\s*t\\s*a\\s*:\\s*t\\s*e\\s*x\\s*t\\s*\\/\\s*h\\s*t\\s*m\\s*l\\s*(,|;))"
+        |> Maybe.withDefault Regex.never
+
+
 escapeRawText : ElementKind -> String.String -> String.String
 escapeRawText kind rawText =
     case kind of
@@ -189,7 +259,14 @@ escapeRawText kind rawText =
             rawText
 
         RawTextElements ->
-            rawText
+            {- Prevent closing tag injection in raw text elements (e.g. <style>).
+               In pre-rendered HTML, </style> in the text content would cause the
+               browser to close the tag early. Inserting a backslash between < and /
+               prevents the HTML parser from recognizing it as a closing tag, since
+               the parser requires </ (not <\) to start an end tag. This doesn't
+               affect CSS validity since </ is already invalid CSS.
+            -}
+            String.replace "</" "<\\/" rawText
 
         _ ->
             escapeHtml rawText


### PR DESCRIPTION
## Summary

- Add XSS sanitization to pre-rendered HTML output, mirroring Elm's virtual-dom guards
- Separate attribute and property decoding to apply the correct sanitization to each
- Prevent closing tag injection in `<style>` elements (a pre-rendering-specific concern)

## Context

When Elm renders in the browser, the DOM API handles escaping natively -- `createTextNode()`, `setAttribute()`, and property assignment all prevent injection by design. Pre-rendered HTML has no such safety net. The HTML is a string, and any unescaped content can alter the document structure.

The virtual-dom includes several [XSS prevention functions](https://github.com/elm/virtual-dom/blob/79d31f5889930aa5d0d8e874a0807076d5c16891/src/Elm/Kernel/VirtualDom.js#L274) that are applied at node construction time in the browser. These guards were not previously applied during pre-rendering, meaning the server-rendered HTML could contain patterns that the client-side virtual-dom would have blocked.

## What changed

### Sanitization functions (mirroring virtual-dom)

Each function matches its virtual-dom counterpart:

| Function | What it does | Virtual-dom equivalent |
|---|---|---|
| `noScript` | `script` -> `p` | `_VirtualDom_noScript` |
| `noOnOrFormAction` | `on*`/`formAction` attrs -> `data-` prefix | `_VirtualDom_noOnOrFormAction` |
| `noInnerHtmlOrFormAction` | `innerHTML`/`outerHTML`/`formAction` props -> `data-` prefix | `_VirtualDom_noInnerHtmlOrFormAction` |
| `noJavaScriptOrHtmlUri` | Strips `javascript:` and `data:text/html` URIs | `_VirtualDom_noJavaScriptOrHtmlUri` |
| `isUnsafeName` | Rejects element/attribute names with `\s`, `\n`, `\`, `/`, `=`, `'`, `"`, `\0`, `<`, `>` | (matches Preact's approach) |
| `escapeHtml` | Escapes `&`, `<`, `>`, `"`, `'` in text and attribute values | `_VirtualDom_text` (server.js) |

### Attribute/property split

Elm's virtual-dom stores attributes and properties separately in its facts structure (attributes under the `a2` key, properties at the top level). The pre-renderer previously merged them into a single dict via `decodeOthers`, which made it impossible to apply the correct sanitization to each type.

They need different guards because they represent different threat models:

- **Attributes** (via `Html.Attributes.attribute`): `noOnOrFormAction` rewrites `on*` and `formAction`, because `setAttribute("onclick", ...)` executes JavaScript.
- **Properties** (via `Html.Attributes.property`, `.class`, etc.): `noInnerHtmlOrFormAction` rewrites `innerHTML`, `outerHTML`, and `formAction`, because `element.innerHTML = ...` injects HTML.

The split also fixes `className` handling -- it's a DOM property, not an HTML attribute, and is now correctly read from `stringProperties`.

### Closing tag injection in raw text elements

This is a concern **specific to pre-rendered HTML** that doesn't exist in client-side DOM rendering.

Raw text elements like `<style>` have their content emitted unescaped (which is correct -- CSS selectors like `>` must not be entity-encoded, since browsers don't parse character references in raw text elements). But this means if the text content contains `</style>`, the browser's HTML parser closes the tag early, and everything after is parsed as HTML:

```elm
Html.node "style" [] [ Html.text "</style><img src=x onerror=alert(1)>" ]
```

Without the fix, pre-rendered output:
```html
<style></style><img src=x onerror=alert(1)></style>
```
The browser sees an empty `<style>`, then an `<img>` element that executes the XSS payload.

The fix replaces `</` with `<\/` in raw text element content. This works because:
- The HTML parser requires `<` immediately followed by `/` to start a closing tag. `<\` is not recognized as a tag start, so the element stays open.
- `</` is already invalid CSS, so inserting `\` doesn't break any valid stylesheets.

(`<script>` is not affected because `noScript` already converts it to `<p>`, which is a normal element whose children get full HTML escaping.)

## Hydration

These changes **strictly improve** hydration compatibility (as discussed in [#519](https://github.com/dillonkearns/elm-pages/pull/519), pre-rendered nodes must match client-rendered nodes for proper adoption).

**For the sanitization functions**: The virtual-dom applies `noScript`, `noOnOrFormAction`, etc. at node construction time in the browser. Without these same guards in pre-rendering, the server-rendered DOM could have a different structure than what the client produces (e.g., a `<script>` tag server-side vs a `<p>` tag client-side). Applying the same guards ensures structural equivalence.

**For the `<style>` closing tag fix**: Without the fix, `</style>` in style content causes the browser to parse a completely different DOM tree (empty style element + injected elements). With the fix, the DOM tree structure matches exactly -- a single `<style>` element with a text node child. The only difference is a `\` character in content that was already invalid CSS, which is a trivial text-level mismatch vs a catastrophic structural mismatch.