### PR TITLE
Pin lamdera and stop downloading lamdera-next in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.elm
-          key: elm-${{ hashFiles('elm.json', 'elm-tooling.json', 'generator/elm.json', 'review/elm.json', 'examples/routing/elm.json', 'examples/escaping/elm.json', 'examples/base-path/elm.json') }}
+          key: elm-v2-${{ hashFiles('elm.json', 'elm-tooling.json', 'generator/elm.json', 'review/elm.json', 'examples/routing/elm.json', 'examples/escaping/elm.json', 'examples/base-path/elm.json') }}
       - name: npm ci
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         env:
@@ -84,7 +84,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ~/.elm
-          key: elm-${{ hashFiles('elm.json', 'elm-tooling.json', 'generator/elm.json', 'review/elm.json', 'examples/routing/elm.json', 'examples/escaping/elm.json', 'examples/base-path/elm.json') }}
+          key: elm-v2-${{ hashFiles('elm.json', 'elm-tooling.json', 'generator/elm.json', 'review/elm.json', 'examples/routing/elm.json', 'examples/escaping/elm.json', 'examples/base-path/elm.json') }}
       - name: npm ci
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,6 @@ jobs:
         with:
           path: ~/.elm
           key: elm-${{ hashFiles('elm.json', 'elm-tooling.json', 'generator/elm.json', 'review/elm.json', 'examples/routing/elm.json', 'examples/escaping/elm.json', 'examples/base-path/elm.json') }}
-      - name: Download lamdera
-        run: curl https://static.lamdera.com/bin/linux/lamdera-next-alpine-musl -o /usr/local/bin/lamdera && chmod a+x /usr/local/bin/lamdera
       - name: npm ci
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         env:
@@ -87,8 +85,6 @@ jobs:
         with:
           path: ~/.elm
           key: elm-${{ hashFiles('elm.json', 'elm-tooling.json', 'generator/elm.json', 'review/elm.json', 'examples/routing/elm.json', 'examples/escaping/elm.json', 'examples/base-path/elm.json') }}
-      - name: Download lamdera
-        run: curl https://static.lamdera.com/bin/linux/lamdera-next-alpine-musl -o /usr/local/bin/lamdera && chmod a+x /usr/local/bin/lamdera
       - name: npm ci
         if: steps.cache-node_modules.outputs.cache-hit != 'true'
         env:

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "elm-test": "^0.19.1-revision17",
         "elm-tooling": "^1.17.0",
         "elm-verify-examples": "^6.0.3",
-        "lamdera": "^0.19.1-1.4.0",
+        "lamdera": "0.19.1-1.4.0",
         "prettier": "^3.8.1",
         "typescript": "^6.0.2",
         "vitest": "^4.1.2"

--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "elm-test": "^0.19.1-revision17",
     "elm-tooling": "^1.17.0",
     "elm-verify-examples": "^6.0.3",
-    "lamdera": "^0.19.1-1.4.0",
+    "lamdera": "0.19.1-1.4.0",
     "prettier": "^3.8.1",
     "typescript": "^6.0.2",
     "vitest": "^4.1.2"


### PR DESCRIPTION
## Summary
- Pin `lamdera` devDependency to exact `0.19.1-1.4.0` (remove caret)
- Remove the `Download lamdera` steps from both the `build` and `cypress` CI jobs, which curl the rolling `lamdera-next-alpine-musl` binary
- CI will now use the pinned npm lamdera via `node_modules/.bin` (already on `$PATH` via the existing step)

## Why
Master CI has been red since sometime between Apr 4 and Apr 10 with:

```
-- INCOMPATIBLE DEPENDENCIES ------------------------------------------ elm.json
```

…at the `npx elm-test --compiler lamdera` step. No repo change landed in that window, so the regression is external — the `lamdera-next-alpine-musl` URL is a rolling "next" build that appears to have drifted into an incompatibility with our `elm.json` dependency solution when elm-test generates its test project. Pinning to the stable npm release removes that moving target.

## Test plan
- [ ] CI `build` job passes (the previously failing `Tests` step runs `./test.sh` → `npx elm-test --compiler lamdera`)
- [ ] CI `cypress` job passes