### PR TITLE
Sort modules alphabetically in generated lcov.info

### DIFF
--- a/generator/src/coverage.js
+++ b/generator/src/coverage.js
@@ -547,7 +547,14 @@ function generateLcov(info, allCounters, projectDirectory, modulePaths) {
   const modules = info.modules || info;
   const sections = [];
 
-  for (const [moduleName, annotations] of Object.entries(modules)) {
+  // Sort by module name so lcov.info is deterministic across filesystems.
+  // elm-instrument's info.json key order follows directory traversal, which
+  // differs between macOS and Linux; downstream tools (and our snapshot tests)
+  // rely on stable output.
+  const sortedEntries = Object.entries(modules).sort(([a], [b]) =>
+    a.localeCompare(b)
+  );
+  for (const [moduleName, annotations] of sortedEntries) {
     const exprList = Array.isArray(annotations) ? annotations : [];
     const hits = allCounters[moduleName] || [];
 


### PR DESCRIPTION
## Summary
Sort modules by name in `generateLcov` so `coverage/lcov.info` is deterministic across filesystems. `printSummary` already does this for the console report (generator/src/coverage.js:451); this just brings `generateLcov` in line.

## Why
The coverage-e2e snapshot test (`generator/test/coverage-e2e/coverage.test.js`) was failing on Linux CI with a diff that only differed in record ordering: `RunGreet.elm` before `Greet.elm` on Linux, the reverse on macOS where the snapshot was taken. The records themselves were byte-identical.

Root cause: `generateLcov` iterates `Object.entries(info.modules)`, where `info.modules` is whatever elm-instrument wrote into `info.json`. elm-instrument's key order follows directory traversal, which is sorted on macOS APFS and insertion-order on Linux ext4. So the same code produced different output on different OSes.

This wasn't caught until now because the whole `test.sh` was short-circuiting earlier on the `INCOMPATIBLE DEPENDENCIES` elm-test failure that PR #598 fixed. With that out of the way, CI now gets far enough to run this test.

The fix is at the right layer: **stable ordering in the output itself**, not normalization in the test. Real consumers of `lcov.info` (coveralls, codecov, diffing tools) benefit from deterministic output, and the test snapshot can stay as a straight byte comparison.

The existing snapshot already has `Greet` before `RunGreet` — which is alphabetical order — so no snapshot update is needed.

## Test plan
- [x] `npx vitest run generator/test/coverage-e2e/coverage.test.js` — all 10 tests pass locally
- [x] CI build job `Tests` step green