### PR TITLE
Fix flaky CI: disable vitest file parallelism

### DIFF
--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    // Disable file-level parallelism. Several test files spawn lamdera/elm
+    // compiler processes that share the global ~/.elm package cache. Running
+    // them concurrently corrupts artifacts.x.dat files, causing flaky
+    // "Corrupt File: not enough bytes" failures.
+    fileParallelism: false,
+  },
+});


### PR DESCRIPTION
Several test files (db-migration-e2e, coverage-e2e, missing-elm-codegen) spawn lamdera/elm compiler processes that share the global ~/.elm package cache. Running them concurrently corrupts artifacts.x.dat files, causing non-deterministic "Corrupt File: not enough bytes" failures.

This has been causing flaky CI on master since the coverage-e2e tests were added (~April 1).