### PR TITLE
Add request/argument assertions to ensureHttpPost and ensureCustom

### DIFF
--- a/examples/todos/tests/TodoTests.elm
+++ b/examples/todos/tests/TodoTests.elm
@@ -31,9 +31,9 @@ suite =
                 ([ PagesProgram.ensureViewHas [ PSelector.text "You aren't logged in yet." ]
                  , PagesProgram.fillIn "login" "email" "user@example.com"
                  , PagesProgram.clickButton "Login"
-                 , PagesProgram.ensureCustom "encrypt"
+                 , PagesProgram.ensureCustom "encrypt" (\_ -> Expect.pass)
                  , PagesProgram.simulateCustom "encrypt" (Encode.string "fake-hash")
-                 , PagesProgram.ensureHttpPost "https://api.sendgrid.com/v3/mail/send"
+                 , PagesProgram.ensureHttpPost "https://api.sendgrid.com/v3/mail/send" (\_ -> Expect.pass)
                  , PagesProgram.simulateHttpPost "https://api.sendgrid.com/v3/mail/send" Encode.null
                  , PagesProgram.ensureViewHas [ PSelector.text "Check your inbox for your login link!" ]
                  , PagesProgram.navigateTo "/login?magic=fake-hash"
@@ -112,7 +112,7 @@ suite =
                 ]
             , PagesProgram.test "loads with a pre-signed session cookie"
                 (startSignedInWithTodos todosResponse)
-                [ PagesProgram.ensureCustom "getTodosBySession"
+                [ PagesProgram.ensureCustom "getTodosBySession" (\_ -> Expect.pass)
                 , PagesProgram.simulateCustom "getTodosBySession" todosResponse
                 , PagesProgram.ensureBrowserUrl (Expect.equal "https://localhost:1234/")
                 , PagesProgram.ensureViewHas [ PSelector.text "todos" ]

--- a/src/Test/PagesProgram.elm
+++ b/src/Test/PagesProgram.elm
@@ -1367,34 +1367,89 @@ ensureHttpGet url =
     Internal.Step (ensurePendingRequest "ensureHttpGet" (\r -> r.method == "GET" && r.url == url) url)
 
 
-{-| Assert that a POST request to the given URL is currently pending.
+{-| Assert that a POST request to the given URL is currently pending, and run an
+assertion on the request body. Does not resolve the request.
+
+    import Expect
+    import Json.Decode as Decode
 
     TestApp.start "/" BackendTaskTest.init
         |> PagesProgram.ensureHttpPost "https://api.example.com/submit"
+            (\body ->
+                Decode.decodeValue (Decode.field "name" Decode.string) body
+                    |> Expect.equal (Ok "Alice")
+            )
         |> PagesProgram.simulateHttpPost "https://api.example.com/submit" response
 
+If you don't need to inspect the body, use `(\_ -> Expect.pass)`.
+
+The body is presented as a `Json.Encode.Value`. JSON request bodies decode
+faithfully; non-JSON bodies (binary, multipart) are passed through as
+`Encode.null`.
+
 -}
-ensureHttpPost : String -> Step model msg
-ensureHttpPost url =
-    Internal.Step (ensurePendingRequest "ensureHttpPost" (\r -> r.method == "POST" && r.url == url) url)
+ensureHttpPost : String -> (Encode.Value -> Expectation) -> Step model msg
+ensureHttpPost url bodyAssertion =
+    Internal.Step
+        (ensurePendingRequestWith
+            "ensureHttpPost"
+            (\r -> r.method == "POST" && r.url == url)
+            (\r -> bodyAssertion (decodePendingBody r.body))
+            url
+        )
 
 
 {-| Assert that a `BackendTask.Custom.run` call with the given port name
-is currently pending.
+is currently pending, and run an assertion on the input arguments. Does not
+resolve the request.
+
+    import Expect
+    import Json.Decode as Decode
 
     TestApp.start "/" BackendTaskTest.init
-        |> PagesProgram.ensureCustom "getTodos"
-        |> PagesProgram.simulateCustom "getTodos" response
+        |> PagesProgram.ensureCustom "hashPassword"
+            (\args ->
+                Decode.decodeValue Decode.string args
+                    |> Expect.equal (Ok "secret123")
+            )
+        |> PagesProgram.simulateCustom "hashPassword" (Encode.string "hashed")
+
+If you don't need to check the arguments, use `(\_ -> Expect.pass)`.
 
 -}
-ensureCustom : String -> Step model msg
-ensureCustom portName =
+ensureCustom : String -> (Encode.Value -> Expectation) -> Step model msg
+ensureCustom portName argsAssertion =
     Internal.Step
-        (ensurePendingRequest
+        (ensurePendingRequestWith
             "ensureCustom"
             (\r -> r.url == "elm-pages-internal://port" && pendingPortName r == Just portName)
+            (\r -> argsAssertion (decodePendingPortInput r.body))
             portName
         )
+
+
+decodePendingBody : Maybe String -> Encode.Value
+decodePendingBody body =
+    case body of
+        Just raw ->
+            Json.Decode.decodeString Json.Decode.value raw
+                |> Result.withDefault Encode.null
+
+        Nothing ->
+            Encode.null
+
+
+decodePendingPortInput : Maybe String -> Encode.Value
+decodePendingPortInput body =
+    case body of
+        Just raw ->
+            Json.Decode.decodeString
+                (Json.Decode.field "input" Json.Decode.value)
+                raw
+                |> Result.withDefault Encode.null
+
+        Nothing ->
+            Encode.null
 
 
 ensurePendingRequest : String -> ({ url : String, method : String, headers : List ( String, String ), body : Maybe String } -> Bool) -> String -> ProgramTest model msg -> ProgramTest model msg
@@ -1415,30 +1470,81 @@ ensurePendingRequest callerName predicate target (ProgramTest state) =
                 ProgramTest state
 
             else
-                let
-                    pendingList =
-                        allPending
-                            |> List.map (\r -> "  " ++ r.method ++ " " ++ r.url)
-                            |> String.join "\n"
-
-                    pendingMsg =
-                        if List.isEmpty allPending then
-                            "No requests are currently pending."
-
-                        else
-                            "Currently pending requests:\n" ++ pendingList
-                in
                 ProgramTest
                     { state
                         | error =
-                            Just
-                                (callerName
-                                    ++ " \""
-                                    ++ target
-                                    ++ "\" failed: no matching request is pending.\n\n"
-                                    ++ pendingMsg
-                                )
+                            Just (noMatchingPendingRequestError callerName target allPending)
                     }
+
+
+ensurePendingRequestWith :
+    String
+    -> ({ url : String, method : String, headers : List ( String, String ), body : Maybe String } -> Bool)
+    -> ({ url : String, method : String, headers : List ( String, String ), body : Maybe String } -> Expectation)
+    -> String
+    -> ProgramTest model msg
+    -> ProgramTest model msg
+ensurePendingRequestWith callerName predicate assertion target (ProgramTest state) =
+    case state.error of
+        Just _ ->
+            ProgramTest state
+
+        Nothing ->
+            let
+                allPending =
+                    gatherAllPendingRequestDetails state
+            in
+            case List.filter predicate allPending |> List.head of
+                Just matched ->
+                    case Test.Runner.getFailureReason (assertion matched) of
+                        Nothing ->
+                            ProgramTest state
+
+                        Just failure ->
+                            ProgramTest
+                                { state
+                                    | error =
+                                        Just
+                                            (callerName
+                                                ++ " \""
+                                                ++ target
+                                                ++ "\" assertion failed.\n\n"
+                                                ++ failure.description
+                                            )
+                                }
+
+                Nothing ->
+                    ProgramTest
+                        { state
+                            | error =
+                                Just (noMatchingPendingRequestError callerName target allPending)
+                        }
+
+
+noMatchingPendingRequestError :
+    String
+    -> String
+    -> List { url : String, method : String, headers : List ( String, String ), body : Maybe String }
+    -> String
+noMatchingPendingRequestError callerName target allPending =
+    let
+        pendingList =
+            allPending
+                |> List.map (\r -> "  " ++ r.method ++ " " ++ r.url)
+                |> String.join "\n"
+
+        pendingMsg =
+            if List.isEmpty allPending then
+                "No requests are currently pending."
+
+            else
+                "Currently pending requests:\n" ++ pendingList
+    in
+    callerName
+        ++ " \""
+        ++ target
+        ++ "\" failed: no matching request is pending.\n\n"
+        ++ pendingMsg
 
 
 {-| Render the list of currently pending requests as a hint appended to

--- a/tests/PagesProgramTest.elm
+++ b/tests/PagesProgramTest.elm
@@ -1671,9 +1671,117 @@ all =
                             , view = \_ model -> { title = "Todos", body = [ Html.text model.todos ] }
                             }
                         )
-                        [ PagesProgram.ensureCustom "getTodos"
+                        [ PagesProgram.ensureCustom "getTodos" (\_ -> Expect.pass)
                         , PagesProgram.simulateCustom "getTodos" (Encode.string "[]")
                         ]
+            , test "asserts on custom port arguments" <|
+                \() ->
+                    PagesProgram.expect
+                        (PagesProgramInternal.initialProgramTest
+                            { data =
+                                BackendTask.Custom.run "hashPassword"
+                                    (Encode.string "secret123")
+                                    Decode.string
+                                    |> BackendTask.allowFatal
+                            , init = \hash -> ( { hash = hash }, [] )
+                            , update = \_ model -> ( model, [] )
+                            , view = \_ model -> { title = "Hash", body = [ Html.text model.hash ] }
+                            }
+                        )
+                        [ PagesProgram.ensureCustom "hashPassword"
+                            (\args ->
+                                Decode.decodeValue Decode.string args
+                                    |> Expect.equal (Ok "secret123")
+                            )
+                        , PagesProgram.simulateCustom "hashPassword"
+                            (Encode.string "hashed")
+                        ]
+            , test "fails when argument assertion fails, naming the port" <|
+                \() ->
+                    PagesProgram.expect
+                        (PagesProgramInternal.initialProgramTest
+                            { data =
+                                BackendTask.Custom.run "hashPassword"
+                                    (Encode.string "actual-value")
+                                    Decode.string
+                                    |> BackendTask.allowFatal
+                            , init = \hash -> ( { hash = hash }, [] )
+                            , update = \_ model -> ( model, [] )
+                            , view = \_ model -> { title = "Hash", body = [ Html.text model.hash ] }
+                            }
+                        )
+                        [ PagesProgram.ensureCustom "hashPassword"
+                            (\args ->
+                                Decode.decodeValue Decode.string args
+                                    |> Expect.equal (Ok "expected-value")
+                            )
+                        ]
+                        |> Expect.all
+                            [ expectFailContaining "ensureCustom"
+                            , expectFailContaining "hashPassword"
+                            , expectFailContaining "expected-value"
+                            , expectFailContaining "actual-value"
+                            ]
+            ]
+        , describe "ensureHttpPost"
+            [ test "asserts on POST request body" <|
+                \() ->
+                    PagesProgram.expect
+                        (PagesProgramInternal.initialProgramTest
+                            { data =
+                                BackendTask.Http.post
+                                    "https://api.example.com/items"
+                                    (BackendTask.Http.jsonBody
+                                        (Encode.object
+                                            [ ( "name", Encode.string "test-item" ) ]
+                                        )
+                                    )
+                                    (BackendTask.Http.expectJson Decode.string)
+                                    |> BackendTask.allowFatal
+                            , init = \value -> ( { value = value }, [] )
+                            , update = \_ model -> ( model, [] )
+                            , view = \_ model -> { title = "Items", body = [ Html.text model.value ] }
+                            }
+                        )
+                        [ PagesProgram.ensureHttpPost "https://api.example.com/items"
+                            (\body ->
+                                Decode.decodeValue (Decode.field "name" Decode.string) body
+                                    |> Expect.equal (Ok "test-item")
+                            )
+                        , PagesProgram.simulateHttpPost "https://api.example.com/items"
+                            (Encode.string "ok")
+                        ]
+            , test "fails when body assertion fails, naming the URL" <|
+                \() ->
+                    PagesProgram.expect
+                        (PagesProgramInternal.initialProgramTest
+                            { data =
+                                BackendTask.Http.post
+                                    "https://api.example.com/items"
+                                    (BackendTask.Http.jsonBody
+                                        (Encode.object
+                                            [ ( "name", Encode.string "actual" ) ]
+                                        )
+                                    )
+                                    (BackendTask.Http.expectJson Decode.string)
+                                    |> BackendTask.allowFatal
+                            , init = \value -> ( { value = value }, [] )
+                            , update = \_ model -> ( model, [] )
+                            , view = \_ model -> { title = "Items", body = [ Html.text model.value ] }
+                            }
+                        )
+                        [ PagesProgram.ensureHttpPost "https://api.example.com/items"
+                            (\body ->
+                                Decode.decodeValue (Decode.field "name" Decode.string) body
+                                    |> Expect.equal (Ok "expected")
+                            )
+                        ]
+                        |> Expect.all
+                            [ expectFailContaining "ensureHttpPost"
+                            , expectFailContaining "api.example.com/items"
+                            , expectFailContaining "expected"
+                            , expectFailContaining "actual"
+                            ]
             ]
         , describe "simulateHttpError"
             [ test "simulates a network error on data loading" <|


### PR DESCRIPTION
## Summary
Enhanced `ensureHttpPost` and `ensureCustom` test helpers to support assertions on request bodies and custom port arguments respectively. This allows test authors to validate the content of pending requests before simulating responses.

## Key Changes
- **`ensureHttpPost`**: Now accepts a callback function to assert on the POST request body as a `Json.Encode.Value`. The body is automatically decoded from JSON, with non-JSON bodies falling back to `Encode.null`.
- **`ensureCustom`**: Now accepts a callback function to assert on the custom port input arguments as a `Json.Encode.Value`.
- **New helper functions**: 
  - `decodePendingBody`: Decodes request body strings to JSON values
  - `decodePendingPortInput`: Extracts and decodes the "input" field from port messages
  - `ensurePendingRequestWith`: Generalized version of `ensurePendingRequest` that runs assertions on matched requests
  - `noMatchingPendingRequestError`: Extracted error message formatting for consistency
- **Updated documentation**: Added comprehensive examples showing how to use the new assertion parameters, including the pattern `(\_ -> Expect.pass)` for cases where body/argument inspection isn't needed.
- **Test coverage**: Added tests validating both successful assertions and failure cases with proper error messages.
- **Updated examples**: Modified existing test code to use the new required parameters.

## Implementation Details
The assertion functions receive the decoded request/argument value and return an `Expectation`. If the expectation fails, the error message is captured and reported with the function name and target URL/port name for context. This maintains consistency with existing error reporting patterns while enabling fine-grained validation of request contents.

https://claude.ai/code/session_014H2CT2Y9shy55VvDLeVZDc