### PR TITLE
Use bind to pass `this`

### DIFF
--- a/generator/src/dev-server.js
+++ b/generator/src/dev-server.js
@@ -1607,10 +1607,10 @@ main =
 function timeMiddleware() {
   return (req, res, next) => {
     const start = Date.now();
-    const end = res.end;
+    const end = res.end.bind(res);
     res.end = (...args) => {
       logTime(`${timeFrom(start)} ${prettifyUrl(req.url)}`);
-      return end.call(res, ...args);
+      return end.call(...args);
     };
 
     next();


### PR DESCRIPTION
I _think_ this version is more correct? It does solve the `Unhandled rejection: TypeError [ERR_INVALID_ARG_TYPE]: The "chunk" argument must be of type string or an instance of Buffer or Uint8Array. Received an instance of Error` I had been getting sporadically.