### PR TITLE
Use Lamdera’s built-in HMR support instead of elm-hot if available

### DIFF
--- a/generator/src/compile-elm.js
+++ b/generator/src/compile-elm.js
@@ -13,6 +13,8 @@ import { transform as eol2Transform } from "elm-optimize-level-2";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
+const LAMDERA_HOT_RELOAD = /^function _Platform_mergeExportsHotReload/m;
+
 export async function compileElmForBrowser(options, config = {}) {
   // TODO do I need to make sure this is run from the right cwd? Before it was run outside of this function in the global scope, need to make sure that doesn't change semantics.
   const pathToClientElm = path.join(
@@ -46,9 +48,12 @@ export async function compileElmForBrowser(options, config = {}) {
 
   // Apply transforms in sequence:
   // 1. elm-hot injection for development
+  //    Skip this if using a version of the Lamdera Compiler which ships built-in hot reloading support
   // 2. Form data stringify replacement
   // 3. Frozen view adoption patch
-  let transformedCode = inject(rawElmCode);
+  let transformedCode = LAMDERA_HOT_RELOAD.test(rawElmCode)
+    ? rawElmCode
+    : inject(rawElmCode);
 
   transformedCode = transformedCode.replace(
     /return \$elm\$json\$Json\$Encode\$string\(.REPLACE_ME_WITH_FORM_TO_STRING.\)/g,

--- a/generator/static-code/hmr.js
+++ b/generator/static-code/hmr.js
@@ -218,9 +218,18 @@ async function thenApplyHmr(response) {
       location.reload();
     } else {
       response.text().then(function (value) {
-        module.hot.apply();
-        delete window.Elm;
-        eval(value);
+        if (window.Elm.hot) {
+          // If the built-in hot reloading from the Lamdera Compiler is available, use that.
+          var f = new Function(value);
+          var newScope = {};
+          f.call(newScope);
+          window.Elm.hot.reload(newScope);
+        } else {
+          // Otherwise apply elm-hot’s hot reloading.
+          module.hot.apply();
+          delete window.Elm;
+          eval(value);
+        }
       });
     }
   } else {


### PR DESCRIPTION
The next version of Lamdera ships with built-in hot reloading support (https://github.com/lamdera/compiler/pull/65), which I believe will break elm-hot. This PR uses the built-in stuff if available – which should also result in better hot reloading! For example, you won’t lose DOM state such as scroll positions of scrollable areas.

Note:

- This is completely untested, but should show the gist of what needs to be done!
- frozen-view-codemod.js mentions elm-hot in a comment. I have not checked if that code needs to be updated as well.
